### PR TITLE
Changed snapshot json serialization settings.

### DIFF
--- a/src/Snapshooter/Core/SnapshotSerializer.cs
+++ b/src/Snapshooter/Core/SnapshotSerializer.cs
@@ -73,6 +73,7 @@ namespace Snapshooter.Core
             {
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
                 Formatting = Formatting.Indented,
+                NullValueHandling = NullValueHandling.Include,
                 Converters = new JsonConverter[]
                 {
                     new StringEnumConverter()
@@ -86,7 +87,8 @@ namespace Snapshooter.Core
             new JsonLoadSettings
             {
                 CommentHandling = CommentHandling.Ignore,
-                LineInfoHandling = LineInfoHandling.Ignore
+                LineInfoHandling = LineInfoHandling.Ignore,
+                DuplicatePropertyNameHandling = DuplicatePropertyNameHandling.Error
             };
     }
 }


### PR DESCRIPTION
The snapshots will be serialized into json. 
We changed the following json serialization settings:

- Null values will be included into json (its the default, we just set is explicitely).
- Duplicate property naming will throw an error (properties must be unique).

