### PR TITLE
Carriage return line feed normalization in snapshot file deserialization.

### DIFF
--- a/src/Snapshooter/Core/SnapshotSerializer.cs
+++ b/src/Snapshooter/Core/SnapshotSerializer.cs
@@ -64,6 +64,10 @@ namespace Snapshooter.Core
 
             if(!isValidJson)
             {
+                snapshotJson = snapshotJson
+                    .NormalizeLineEndings()
+                    .EnsureLineEnding();
+
                 snapshotJson = JsonConvert.ToString(snapshotJson);
             }
 

--- a/src/Snapshooter/SnapshotAssert.cs
+++ b/src/Snapshooter/SnapshotAssert.cs
@@ -71,9 +71,17 @@ namespace Snapshooter
 
             string actualSnapshotSerialized = _snapshotSerializer.SerializeObject(currentResult);
             string savedSnapshotSerialized = _snapshotFileHandler.ReadSnapshot(snapshotFullName);
+
+            if (savedSnapshotSerialized == null)
+            {
+                _snapshotFileHandler
+                    .SaveNewSnapshot(snapshotFullName, actualSnapshotSerialized);
+
+                return;
+            }
                        
             CompareSnapshots(actualSnapshotSerialized, savedSnapshotSerialized,
-                snapshotFullName, matchOptions);
+                    snapshotFullName, matchOptions);
         }
 
         private void CompareSnapshots(
@@ -82,14 +90,6 @@ namespace Snapshooter
             SnapshotFullName snapshotFullName,
             Func<MatchOptions, MatchOptions> matchOptions)
         {
-            if (savedSnapshotSerialized == null)
-            {
-                _snapshotFileHandler
-                    .SaveNewSnapshot(snapshotFullName, actualSnapshotSerialized);
-
-                return;
-            }
-
             try
             {
                 _snapshotComparer.CompareSnapshots(


### PR DESCRIPTION
When snapshot files contain text only, then the text line ends will be normalized.
