### PR TITLE
Liveunittestfix

### DIFF
--- a/src/Snapshooter.Xunit.Tests/LiveUnitTesting/LiveUnitTestingDirectoryResolverTests.cs
+++ b/src/Snapshooter.Xunit.Tests/LiveUnitTesting/LiveUnitTestingDirectoryResolverTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Snapshooter.Exceptions;
+using Xunit;
+
+namespace Snapshooter.Xunit.Tests.LiveUnitTesting
+{
+    public class LiveUnitTestingDirectoryResolverTests
+    {
+
+        [Fact]
+        public void TryResolveName_OneFile_FullNameCorrect()
+        {
+            // arrange
+            var tempDir = ArrangeLiveUnitTestDirectory("Test1.cs");
+            var testName = "Test1.Foo";
+
+            // act
+            SnapshotFullName fullName = LiveUnitTestingDirectoryResolver
+                               .TryResolveName(testName);
+
+            // assert
+            fullName.Should().NotBeNull();
+            fullName.FolderPath.Should().Be( Path.Combine(tempDir,"1"));
+            fullName.Filename.Should().Be(testName);
+        }
+
+        [Fact]
+        public void TryResolveName_TwoFiles_SnapshotTestException()
+        {
+            // arrange
+            ArrangeLiveUnitTestDirectory("Test1.cs", "Test1.cs");
+            var testName = "Test1.Foo";
+
+            // act
+            Func<SnapshotFullName> action =
+                    () => LiveUnitTestingDirectoryResolver
+                            .TryResolveName(testName);
+
+            // assert
+            action.Should().Throw<SnapshotTestException>();
+        }
+
+        [Fact]
+        public void TryResolveName_NoFileMatch_ResultIsNull()
+        {
+            // arrange
+            ArrangeLiveUnitTestDirectory("Test2.cs");
+            var testName = "Test1.Foo";
+
+            // act
+            SnapshotFullName fullName = LiveUnitTestingDirectoryResolver
+                               .TryResolveName(testName);
+
+            // assert
+            fullName.Should().BeNull();
+        }
+
+        [Fact]
+        public void CheckForSession_PathSet_ReturnSame()
+        {
+            // arrange
+            var snapshotFullName = new SnapshotFullName("filename", "dirname");
+
+            // act
+            SnapshotFullName fullNameResult = LiveUnitTestingDirectoryResolver
+                                    .CheckForSession(snapshotFullName);
+
+            // assert
+            fullNameResult.Should().NotBeNull();
+            fullNameResult.Filename.Should().Be(snapshotFullName.Filename);
+            fullNameResult.FolderPath.Should().Be(snapshotFullName.FolderPath);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void CheckForSession_PathIsNullOrEmpty_SnapshotTestException(string path)
+        {
+            // arrange
+            var snapshotFullName = new SnapshotFullName("filename", path);
+
+            // act
+            Func<SnapshotFullName> action = () => LiveUnitTestingDirectoryResolver
+                                                    .CheckForSession(snapshotFullName);
+
+            // assert
+            action.Should().Throw<SnapshotTestException>();
+        }
+
+
+
+        private string ArrangeLiveUnitTestDirectory(params string[] files)
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(),
+                                       "snapshooter",
+                                       Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            int fileNr = 1;
+            foreach (var file in files)
+            {
+                var fileDir = Path.Combine(tempDir, fileNr.ToString());
+                Directory.CreateDirectory(fileDir);
+                File.WriteAllText(Path.Combine(fileDir, file), file);
+                fileNr++;
+            }
+            var liveUnitTestFake = Path.Combine(tempDir, ".vs", "some", "liveunittest");
+            Directory.CreateDirectory(liveUnitTestFake);
+            Directory.SetCurrentDirectory(liveUnitTestFake);
+            return tempDir;
+        }
+
+
+
+
+    }
+}

--- a/src/Snapshooter.Xunit/AssemblyInfo.cs
+++ b/src/Snapshooter.Xunit/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Snapshooter.Xunit.Tests")]

--- a/src/Snapshooter.Xunit/LiveUnitTestingDirectoryResolver.cs
+++ b/src/Snapshooter.Xunit/LiveUnitTestingDirectoryResolver.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Snapshooter.Exceptions;
+
+namespace Snapshooter.Xunit
+{
+    /// <summary>
+    /// A class to help resolving the directory in which the test is executed when running
+    /// in a Visual Studio Live Unit Testing session
+    /// </summary>
+    internal static class LiveUnitTestingDirectoryResolver
+    {
+        internal static SnapshotFullName TryResolveName(string testname)
+        {
+            var currentDir = Directory.GetCurrentDirectory();
+            if (currentDir.ToLower().Contains("liveunittest"))
+            {
+                var srcPath = currentDir.Substring(0, currentDir.IndexOf(".vs") - 1);
+                var filename = testname.Split('.').FirstOrDefault() + ".cs";
+                var files = Directory.GetFiles(srcPath, filename, SearchOption.AllDirectories);
+                if (files.Length == 1)
+                {
+                    return new SnapshotFullName(testname, Path.GetDirectoryName(files[0]));
+                }
+                else if (files.Length > 1)
+                {
+                    throw new SnapshotTestException(
+                            $"Multiple files found with '{filename}' this can happen " +
+                             "in Visual Studio Live Unit session while trying to resolve " +
+                             "the directory name. " +
+                             "To solve this issue either stop Live Unit Testing or " +
+                             "make sure testfile names are unique. " +
+                            $"Duplicate files are:{Environment.NewLine}{string.Join(Environment.NewLine, files)}");
+                }
+            }
+            return null;
+        }
+
+        internal static SnapshotFullName CheckForSession(SnapshotFullName snapshotFullName)
+        {
+            if (string.IsNullOrEmpty(snapshotFullName.FolderPath))
+            {
+                snapshotFullName = TryResolveName(snapshotFullName.Filename);
+
+                if (string.IsNullOrEmpty(snapshotFullName?.FolderPath))
+                {
+                    throw new SnapshotTestException("Could not resolve directory for SnapShot");
+                }
+            }
+            return snapshotFullName;
+        }
+    }
+}

--- a/src/Snapshooter.Xunit/XunitSnapshotFullNameReader.cs
+++ b/src/Snapshooter.Xunit/XunitSnapshotFullNameReader.cs
@@ -60,44 +60,13 @@ namespace Snapshooter.Xunit
                     "Snapshot.Match method.");
             }
 
-            if (string.IsNullOrEmpty(snapshotFullName.FolderPath))
-            {
-                snapshotFullName = TryResolveNameInLiveUnitTestingSession(snapshotFullName.Filename);
+            snapshotFullName = LiveUnitTestingDirectoryResolver
+                                    .CheckForSession(snapshotFullName);
 
-                if (string.IsNullOrEmpty(snapshotFullName.FolderPath))
-                {
-                    throw new SnapshotTestException("Could not resove directory for SnapShot");
-                }
-            }
+
+
 
             return snapshotFullName;
-        }
-
-
-        private SnapshotFullName TryResolveNameInLiveUnitTestingSession(string testname)
-        {
-            var currentDir = Directory.GetCurrentDirectory();
-            if (currentDir.ToLower().Contains("liveunittest"))
-            {
-                var srcPath = currentDir.Substring(0, currentDir.IndexOf(".vs") - 1);
-                var filename = testname.Split('.').FirstOrDefault() + ".cs";
-                var files = Directory.GetFiles(srcPath, filename, SearchOption.AllDirectories);
-                if (files.Length == 1)
-                {
-                    return new SnapshotFullName(testname, Path.GetDirectoryName(files[0]));
-                }
-                else if (files.Length > 1)
-                {
-                    throw new SnapshotTestException(
-                            $"Multiple files found with '{filename}' this can happen " +
-                             "in Visual Studio Live Unit session while trying to resolve " +
-                             "the directory name. " +
-                             "To solve this issue either stop Live Unit Testing or " +
-                             "make sure testfile names are unique. " +
-                            $"Duplicate files are:{Environment.NewLine}{string.Join(Environment.NewLine, files)}");
-                }
-            }
-            return null;
         }
 
         private static bool IsXunitTestMethod(MemberInfo method)

--- a/src/Snapshooter.Xunit/XunitSnapshotFullNameReader.cs
+++ b/src/Snapshooter.Xunit/XunitSnapshotFullNameReader.cs
@@ -26,16 +26,15 @@ namespace Snapshooter.Xunit
         {
             SnapshotFullName snapshotFullName = null;
             StackFrame[] stackFrames = new StackTrace(true).GetFrames();
-
             foreach (StackFrame stackFrame in stackFrames)
             {
                 MethodBase method = stackFrame.GetMethod();
-
                 if (IsXunitTestMethod(method))
                 {
                     snapshotFullName = new SnapshotFullName(
                         method.ToName(),
                         Path.GetDirectoryName(stackFrame.GetFileName()));
+
                     break;
                 }
 
@@ -45,6 +44,7 @@ namespace Snapshooter.Xunit
                     snapshotFullName = new SnapshotFullName(
                         asyncMethod.ToName(),
                         Path.GetDirectoryName(stackFrame.GetFileName()));
+
                     break;
                 }
             }
@@ -69,8 +69,10 @@ namespace Snapshooter.Xunit
                     throw new SnapshotTestException("Could not resove directory for SnapShot");
                 }
             }
+
             return snapshotFullName;
         }
+
 
         private SnapshotFullName TryResolveNameInLiveUnitTestingSession(string testname)
         {


### PR DESCRIPTION
Extended ReadSnapshotFullName to resolve source directory when running in a VS "Live Unit Test" session.

Fixed bug: #46
