### PR TITLE
Fluent assertion support

### DIFF
--- a/src/Snapshooter.Xunit.Tests/SnapshotExtensionTests.cs
+++ b/src/Snapshooter.Xunit.Tests/SnapshotExtensionTests.cs
@@ -1,0 +1,20 @@
+using Xunit;
+using FluentAssertions;
+using Snapshooter.Tests.Data;
+
+
+namespace Snapshooter.Xunit.Tests
+{
+    public class SnapshotExtensionTests
+    {
+        [Fact]
+        public void MatchSnapshot_ShouldFluentAssertions_RemovesSubject()
+        {
+            // arrange
+            TestPerson testPerson = TestDataBuilder.TestPersonMarkWalton().Build();
+
+            // act & assert
+            testPerson.Should().MatchSnapshot();
+        }
+    }
+}

--- a/src/Snapshooter.Xunit.Tests/SnapshotExtensionTests.cs
+++ b/src/Snapshooter.Xunit.Tests/SnapshotExtensionTests.cs
@@ -16,5 +16,15 @@ namespace Snapshooter.Xunit.Tests
             // act & assert
             testPerson.Should().MatchSnapshot();
         }
+
+        [Fact]
+        public void MatchSnapshot_PlainExtension_CorrectSnapshot()
+        {
+            // arrange
+            TestPerson testPerson = TestDataBuilder.TestPersonMarkWalton().Build();
+
+            // act & assert
+            testPerson.Should().MatchSnapshot();
+        }
     }
 }

--- a/src/Snapshooter.Xunit.Tests/SnapshotExtensionTests.cs
+++ b/src/Snapshooter.Xunit.Tests/SnapshotExtensionTests.cs
@@ -34,7 +34,7 @@ namespace Snapshooter.Xunit.Tests
             TestPerson testPerson = TestDataBuilder.TestPersonMarkWalton().Build();
 
             // act & assert
-            testPerson.Should().MatchSnapshot();
+            testPerson.MatchSnapshot();
         }
     }
 }

--- a/src/Snapshooter.Xunit.Tests/SnapshotExtensionTests.cs
+++ b/src/Snapshooter.Xunit.Tests/SnapshotExtensionTests.cs
@@ -18,6 +18,16 @@ namespace Snapshooter.Xunit.Tests
         }
 
         [Fact]
+        public void MatchSnapshot_ShouldFluentAssertionsNameOf_RemovesSubject()
+        {
+            // arrange
+            TestPerson testPerson = TestDataBuilder.TestPersonMarkWalton().Build();
+
+            // act & assert
+            testPerson.Should().MatchSnapshot(nameof(MatchSnapshot_ShouldFluentAssertionsNameOf_RemovesSubject));
+        }
+
+        [Fact]
         public void MatchSnapshot_PlainExtension_CorrectSnapshot()
         {
             // arrange

--- a/src/Snapshooter.Xunit.Tests/__snapshots__/MatchSnapshot_ShouldFluentAssertionsNameOf_RemovesSubject.snap
+++ b/src/Snapshooter.Xunit.Tests/__snapshots__/MatchSnapshot_ShouldFluentAssertionsNameOf_RemovesSubject.snap
@@ -1,0 +1,56 @@
+﻿{
+  "Id": "c78c698f-9ee5-4b4b-9a0e-ef729b1f8ec8",
+  "Firstname": "Mark",
+  "Lastname": "Walton",
+  "CreationDate": "2018-06-06T00:00:00",
+  "DateOfBirth": "2000-06-25T00:00:00",
+  "Age": 30,
+  "Size": 182.5214,
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  },
+  "Children": [
+    {
+      "Name": "James",
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": null,
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": "Hanna",
+      "DateOfBirth": "2012-03-20T00:00:00"
+    }
+  ],
+  "Relatives": [
+    {
+      "Id": "fcf04ca6-d8f2-4214-a3ff-d0ded5bad4de",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Size": 165.23,
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      },
+      "Children": [],
+      "Relatives": null
+    }
+  ]
+}

--- a/src/Snapshooter.Xunit.Tests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_PlainExtension_CorrectSnapshot.snap
+++ b/src/Snapshooter.Xunit.Tests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_PlainExtension_CorrectSnapshot.snap
@@ -1,0 +1,56 @@
+﻿{
+  "Id": "c78c698f-9ee5-4b4b-9a0e-ef729b1f8ec8",
+  "Firstname": "Mark",
+  "Lastname": "Walton",
+  "CreationDate": "2018-06-06T00:00:00",
+  "DateOfBirth": "2000-06-25T00:00:00",
+  "Age": 30,
+  "Size": 182.5214,
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  },
+  "Children": [
+    {
+      "Name": "James",
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": null,
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": "Hanna",
+      "DateOfBirth": "2012-03-20T00:00:00"
+    }
+  ],
+  "Relatives": [
+    {
+      "Id": "fcf04ca6-d8f2-4214-a3ff-d0ded5bad4de",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Size": 165.23,
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      },
+      "Children": [],
+      "Relatives": null
+    }
+  ]
+}

--- a/src/Snapshooter.Xunit.Tests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_ShouldFluentAssertions_RemovesSubject.snap
+++ b/src/Snapshooter.Xunit.Tests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_ShouldFluentAssertions_RemovesSubject.snap
@@ -1,0 +1,56 @@
+﻿{
+  "Id": "c78c698f-9ee5-4b4b-9a0e-ef729b1f8ec8",
+  "Firstname": "Mark",
+  "Lastname": "Walton",
+  "CreationDate": "2018-06-06T00:00:00",
+  "DateOfBirth": "2000-06-25T00:00:00",
+  "Age": 30,
+  "Size": 182.5214,
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  },
+  "Children": [
+    {
+      "Name": "James",
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": null,
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": "Hanna",
+      "DateOfBirth": "2012-03-20T00:00:00"
+    }
+  ],
+  "Relatives": [
+    {
+      "Id": "fcf04ca6-d8f2-4214-a3ff-d0ded5bad4de",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Size": 165.23,
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      },
+      "Children": [],
+      "Relatives": null
+    }
+  ]
+}

--- a/src/Snapshooter.Xunit/ObjectWrapperRemover.cs
+++ b/src/Snapshooter.Xunit/ObjectWrapperRemover.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Reflection;
+
+namespace Snapshooter.Xunit
+{
+    public static class ObjectWrapperRemover
+    {
+        public static object RemoveUnwantedWrappers(this object objectToRemoveWrappers)
+        {
+            objectToRemoveWrappers.RemoveFluentAssertionWrapper();
+
+            return objectToRemoveWrappers;
+        }
+
+        private static object RemoveFluentAssertionWrapper(this object objectToRemoveWrappers)
+        {
+            Type resultType = objectToRemoveWrappers.GetType();
+
+            if (resultType.Namespace.Equals("FluentAssertions.Primitives")
+                && resultType.Name.Equals("ObjectAssertions"))
+            {
+                PropertyInfo prop = resultType.GetProperty("Subject");
+                object actualvalue = prop.GetValue(objectToRemoveWrappers);
+
+                return actualvalue;
+            }
+
+            return objectToRemoveWrappers;
+        }
+    }
+}

--- a/src/Snapshooter.Xunit/ObjectWrapperRemover.cs
+++ b/src/Snapshooter.Xunit/ObjectWrapperRemover.cs
@@ -7,9 +7,9 @@ namespace Snapshooter.Xunit
     {
         public static object RemoveUnwantedWrappers(this object objectToRemoveWrappers)
         {
-            objectToRemoveWrappers.RemoveFluentAssertionWrapper();
+            object cleanedObject = objectToRemoveWrappers.RemoveFluentAssertionWrapper();
 
-            return objectToRemoveWrappers;
+            return cleanedObject;
         }
 
         private static object RemoveFluentAssertionWrapper(this object objectToRemoveWrappers)

--- a/src/Snapshooter.Xunit/SnapshotExtension.cs
+++ b/src/Snapshooter.Xunit/SnapshotExtension.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 
 namespace Snapshooter.Xunit
 {
@@ -18,7 +17,8 @@ namespace Snapshooter.Xunit
         public static void MatchSnapshot(this object currentResult,
                                  Func<MatchOptions, MatchOptions> matchOptions = null)
         {
-            Snapshot.Match(RemoveUnwantedWrappers(currentResult), matchOptions);
+            var cleanedObject = currentResult.RemoveUnwantedWrappers();
+            Snapshot.Match(cleanedObject, matchOptions);
         }
 
         /// <summary>
@@ -44,7 +44,8 @@ namespace Snapshooter.Xunit
                                  SnapshotNameExtension snapshotNameExtension,
                                  Func<MatchOptions, MatchOptions> matchOptions = null)
         {
-            Snapshot.Match(RemoveUnwantedWrappers(currentResult), snapshotNameExtension, matchOptions);
+            var cleanedObject = currentResult.RemoveUnwantedWrappers();
+            Snapshot.Match(cleanedObject, snapshotNameExtension, matchOptions);
         }
 
         /// <summary>
@@ -65,7 +66,8 @@ namespace Snapshooter.Xunit
                                  string snapshotName,
                                  Func<MatchOptions, MatchOptions> matchOptions = null)
         {
-            Snapshot.Match(RemoveUnwantedWrappers(currentResult), snapshotName, matchOptions);
+            var cleanedObject = currentResult.RemoveUnwantedWrappers();
+            Snapshot.Match(cleanedObject, snapshotName, matchOptions);
         }
 
         /// <summary>
@@ -96,23 +98,8 @@ namespace Snapshooter.Xunit
                                  SnapshotNameExtension snapshotNameExtension,
                                  Func<MatchOptions, MatchOptions> matchOptions = null)
         {
-            Snapshot.Match(RemoveUnwantedWrappers(currentResult), snapshotName, snapshotNameExtension, matchOptions);
-        }
-
-        private static object RemoveUnwantedWrappers(object objectToRemoveWrappers)
-        {
-            Type resultType = objectToRemoveWrappers.GetType();
-
-            if (resultType.Namespace.Equals("FluentAssertions.Primitives")
-                && resultType.Name.Equals("ObjectAssertions"))
-            {
-                PropertyInfo prop = resultType.GetProperty("Subject");
-                object actualvalue = prop.GetValue(objectToRemoveWrappers);
-
-                return actualvalue;
-            }
-
-            return objectToRemoveWrappers;
+            var cleanedObject = currentResult.RemoveUnwantedWrappers();
+            Snapshot.Match(cleanedObject, snapshotName, snapshotNameExtension, matchOptions);
         }
     }
 }

--- a/src/Snapshooter.Xunit/SnapshotExtension.cs
+++ b/src/Snapshooter.Xunit/SnapshotExtension.cs
@@ -1,28 +1,29 @@
 ﻿using System;
+using System.Reflection;
 
 namespace Snapshooter.Xunit
 {
     public static class SnapshotExtension
     {
-        /// <summary>        
-        /// Creates a json snapshot of the given object and compares it with the 
-        /// already existing snapshot of the test. 
+        /// <summary>
+        /// Creates a json snapshot of the given object and compares it with the
+        /// already existing snapshot of the test.
         /// If no snapshot exists, a new snapshot will be created from the current result
         /// and saved under a certain file path, which will shown within the test message.
         /// </summary>
-        /// <param name="currentResult">The object to match.</param> 
+        /// <param name="currentResult">The object to match.</param>
         /// <param name="matchOptions">
         /// Additional compare actions, which can be applied during the snapshot comparison
         /// </param>
         public static void MatchSnapshot(this object currentResult,
                                  Func<MatchOptions, MatchOptions> matchOptions = null)
         {
-            Snapshot.Match(currentResult, matchOptions);
+            Snapshot.Match(RemoveUnwantedWrappers(currentResult), matchOptions);
         }
 
-        /// <summary>        
-        /// Creates a json snapshot of the given object and compares it with the 
-        /// already existing snapshot of the test. 
+        /// <summary>
+        /// Creates a json snapshot of the given object and compares it with the
+        /// already existing snapshot of the test.
         /// If no snapshot exists, a new snapshot will be created from the current result
         /// and saved under a certain file path, which will shown within the test message.
         /// </summary>
@@ -30,8 +31,8 @@ namespace Snapshooter.Xunit
         /// <param name="snapshotNameExtension">
         /// The snapshot name extension will extend the generated snapshot name with
         /// this given extensions. It can be used to make a snapshot name even more
-        /// specific. 
-        /// Example: 
+        /// specific.
+        /// Example:
         /// Generated Snapshotname = 'NumberAdditionTest'
         /// Snapshot name extension = '5', '6', 'Result', '11'
         /// Result: 'NumberAdditionTest_5_6_Result_11'
@@ -43,20 +44,20 @@ namespace Snapshooter.Xunit
                                  SnapshotNameExtension snapshotNameExtension,
                                  Func<MatchOptions, MatchOptions> matchOptions = null)
         {
-            Snapshot.Match(currentResult, snapshotNameExtension, matchOptions);
+            Snapshot.Match(RemoveUnwantedWrappers(currentResult), snapshotNameExtension, matchOptions);
         }
 
-        /// <summary>        
-        /// Creates a json snapshot of the given object and compares it with the 
-        /// already existing snapshot of the test. 
+        /// <summary>
+        /// Creates a json snapshot of the given object and compares it with the
+        /// already existing snapshot of the test.
         /// If no snapshot exists, a new snapshot will be created from the current result
         /// and saved under a certain file path, which will shown within the test message.
         /// </summary>
         /// <param name="currentResult">The object to match.</param>
         /// <param name="snapshotName">
-        /// The name of the snapshot. If not set, then the snapshotname 
+        /// The name of the snapshot. If not set, then the snapshotname
         /// will be evaluated automatically from the xunit test name.
-        /// </param>  
+        /// </param>
         /// <param name="matchOptions">
         /// Additional compare actions, which can be applied during the snapshot comparison
         /// </param>
@@ -64,25 +65,25 @@ namespace Snapshooter.Xunit
                                  string snapshotName,
                                  Func<MatchOptions, MatchOptions> matchOptions = null)
         {
-            Snapshot.Match(currentResult, snapshotName, matchOptions);
+            Snapshot.Match(RemoveUnwantedWrappers(currentResult), snapshotName, matchOptions);
         }
 
-        /// <summary>        
-        /// Creates a json snapshot of the given object and compares it with the 
-        /// already existing snapshot of the test. 
+        /// <summary>
+        /// Creates a json snapshot of the given object and compares it with the
+        /// already existing snapshot of the test.
         /// If no snapshot exists, a new snapshot will be created from the current result
         /// and saved under a certain file path, which will shown within the test message.
         /// </summary>
         /// <param name="currentResult">The object to match.</param>
         /// <param name="snapshotName">
-        /// The name of the snapshot. If not set, then the snapshotname 
+        /// The name of the snapshot. If not set, then the snapshotname
         /// will be evaluated automatically from the xunit test name.
-        /// </param> 
+        /// </param>
         /// <param name="snapshotNameExtension">
         /// The snapshot name extension will extend the generated snapshot name with
         /// this given extensions. It can be used to make a snapshot name even more
-        /// specific. 
-        /// Example: 
+        /// specific.
+        /// Example:
         /// Generated Snapshotname = 'NumberAdditionTest'
         /// Snapshot name extension = '5', '6', 'Result', '11'
         /// Result: 'NumberAdditionTest_5_6_Result_11'
@@ -95,7 +96,23 @@ namespace Snapshooter.Xunit
                                  SnapshotNameExtension snapshotNameExtension,
                                  Func<MatchOptions, MatchOptions> matchOptions = null)
         {
-            Snapshot.Match(currentResult, snapshotName, snapshotNameExtension, matchOptions);
+            Snapshot.Match(RemoveUnwantedWrappers(currentResult), snapshotName, snapshotNameExtension, matchOptions);
+        }
+
+        private static object RemoveUnwantedWrappers(object objectToRemoveWrappers)
+        {
+            Type resultType = objectToRemoveWrappers.GetType();
+
+            if (resultType.Namespace.Equals("FluentAssertions.Primitives")
+                && resultType.Name.Equals("ObjectAssertions"))
+            {
+                PropertyInfo prop = resultType.GetProperty("Subject");
+                object actualvalue = prop.GetValue(objectToRemoveWrappers);
+
+                return actualvalue;
+            }
+
+            return objectToRemoveWrappers;
         }
     }
 }


### PR DESCRIPTION
**Summary of the changes**

- Removes "Subject" Property when using FluentAssertions. Snapshots now look the same, no matter if you use FluentAssertions or not

Resolves #56 
