### PR TITLE
Changed the ordering of the properties to always child properties first

### DIFF
--- a/src/Snapshooter.Xunit.Tests/InheritanceTests/SnapshotInheritanceTests.cs
+++ b/src/Snapshooter.Xunit.Tests/InheritanceTests/SnapshotInheritanceTests.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using Xunit;
+
+namespace Snapshooter.Xunit.Tests
+{
+    public class SnapshotInheritanceTests
+    {
+        [Fact]
+        public void Match_InheritedObjectSnapshotTest_Successful()
+        {
+            // arrange
+            var developer = new Developer
+            {
+                Language = "C#",
+                Level = "Senior",
+                Id = Guid.Parse("7066B471-64C6-4D15-B8F0-19924D200CA9"),
+                Number = 234345,
+                LoginName = "toddm",
+                Name = "Smith",
+                Firstname = "Todd",
+                Gender = "male"
+            };
+
+            // act & assert
+            Snapshot.Match<Developer>(developer);
+        }
+
+        [Fact]
+        public void Match_InheritedObjectsSnapshotTest_Successful()
+        {
+            // arrange
+            var person = new Person
+            {
+                Gender = "male",
+                Firstname = "Mike",
+                Name = "Brown"
+            };
+
+            var employee = new Employee
+            {
+                Firstname = "Ester",
+                LoginName = "oppa",
+                Number = 1989,
+                Gender = "female",
+                Name = "Miller",
+                Id = Guid.Parse("47339B82-CE83-4651-A50A-87340774B17B"),
+            };
+
+            // act & assert
+            Snapshot.Match(new {person, employee});
+        }
+
+        [Fact]
+        public void Match_InheritedObjectOverrideVirtualPropertyTest_Successful()
+        {
+            // arrange
+            var overrideVirtualDeveloper = new OverrideVirtualDeveloper
+            {
+                Language = "Java",
+                Level = "Professional",
+                Firstname = "Ester",
+                LoginName = "oppa",
+                Number = 1989,
+                Gender = "female",
+                Name = "Miller",
+                Id = Guid.Parse("47339B82-CE83-4651-A50A-87340774B17B"),
+            };
+
+            // act & assert
+            Snapshot.Match(overrideVirtualDeveloper);
+        }
+
+        [Fact]
+        public void Match_InheritedObjectOverrideAbstractPropertyTest_Successful()
+        {
+            // arrange
+            var overrideAbstractDeveloper = new OverrideAbstractDeveloper
+            {
+                Language = "Java",
+                Level = "Professional",
+                Firstname = "Ester",
+                LoginName = "oppa",
+                Number = 1989,
+                Gender = "female",
+                Name = "Miller",
+                Id = Guid.Parse("47339B82-CE83-4651-A50A-87340774B17B"),
+            };
+
+            // act & assert
+            Snapshot.Match(overrideAbstractDeveloper);
+        }
+
+        [Fact]
+        public void Match_InheritedObjectNotOverrideVirtualPropertyTest_Successful()
+        {
+            // arrange
+            var notOverrideVirtualDeveloper = new NotOverrideVirtualDeveloper
+            {
+                Language = "Java",
+                Level = "Professional",
+                Firstname = "Ester",
+                LoginName = "oppa",
+                Number = 1989,
+                Gender = "female",
+                Name = "Miller",
+                Id = Guid.Parse("47339B82-CE83-4651-A50A-87340774B17B"),
+            };
+
+            // act & assert
+            Snapshot.Match(notOverrideVirtualDeveloper);
+        }
+
+        [Fact]
+        public void Match_InheritedObjectNewVirtualPropertyTest_Successful()
+        {
+            // arrange
+            var newVirtualDeveloper = new NewVirtualDeveloper
+            {
+                Language = "Java",
+                Level = "Professional",
+                Firstname = "Ester",
+                LoginName = "oppa",
+                Number = 1989,
+                Gender = "female",
+                Name = "Miller",
+                Id = Guid.Parse("47339B82-CE83-4651-A50A-87340774B17B"),
+            };
+
+            // act & assert
+            Snapshot.Match(newVirtualDeveloper);
+        }
+
+        [Fact]
+        public void Match_InheritedObjectOverrideVirtualPropertyOfGrandParentsTest_Successful()
+        {
+            // arrange
+            var overrideVirtualLoginName = new OverrideVirtualLoginName
+            {
+                Language = "Java",
+                Level = "Professional",
+                Firstname = "Ester",
+                LoginName = "oppa",
+                Number = 1989,
+                Gender = "female",
+                Name = "Miller",
+                Id = Guid.Parse("47339B82-CE83-4651-A50A-87340774B17B"),
+            };
+
+            // act & assert
+            Snapshot.Match(overrideVirtualLoginName);
+        }
+
+        private class OverrideVirtualLoginName : Developer
+        {
+            public override string LoginName { get; set; }
+        }
+
+        private class OverrideAbstractDeveloper : AbstractDeveloper
+        {
+            public override string Level { get; set; }
+        }
+
+        private class NewVirtualDeveloper : VirtualDeveloper
+        {
+            public new string Level { get; set; }
+        }
+
+        private class OverrideVirtualDeveloper : VirtualDeveloper
+        {
+            public override string Level { get; set; }
+        }
+        
+        private class NotOverrideVirtualDeveloper : VirtualDeveloper
+        {
+        }
+
+        private abstract class AbstractDeveloper : Employee
+        {
+            public string Language { get; set; }
+
+            public abstract string Level { get; set; }
+        }
+
+        private class VirtualDeveloper : Employee
+        {
+            public string Language { get; set; }
+
+            public virtual string Level { get; set; }
+        }
+
+        private class Developer : Employee
+        {
+            public string Language { get; set; }
+            
+            public string Level { get; set; }
+        }
+
+        private class Employee : Person
+        {
+            public Guid Id { get; set; }
+
+            public int Number { get; set; }
+
+            public virtual string LoginName { get; set; }
+        }
+
+        private class Person : Human
+        {
+            public string Name { get; set; }
+
+            public string Firstname { get; set; }
+        }
+
+        private abstract class Human
+        {
+            protected Human() { }
+
+            public string Gender { get; set; }
+        }
+    }
+}

--- a/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectNewVirtualPropertyTest_Successful.snap
+++ b/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectNewVirtualPropertyTest_Successful.snap
@@ -1,0 +1,10 @@
+﻿{
+  "Level": "Professional",
+  "Language": "Java",
+  "Id": "47339b82-ce83-4651-a50a-87340774b17b",
+  "Number": 1989,
+  "LoginName": "oppa",
+  "Name": "Miller",
+  "Firstname": "Ester",
+  "Gender": "female"
+}

--- a/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectNotOverrideVirtualPropertyTest_Successful.snap
+++ b/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectNotOverrideVirtualPropertyTest_Successful.snap
@@ -1,0 +1,10 @@
+﻿{
+  "Language": "Java",
+  "Level": "Professional",
+  "Id": "47339b82-ce83-4651-a50a-87340774b17b",
+  "Number": 1989,
+  "LoginName": "oppa",
+  "Name": "Miller",
+  "Firstname": "Ester",
+  "Gender": "female"
+}

--- a/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectOverrideAbstractPropertyTest_Successful.snap
+++ b/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectOverrideAbstractPropertyTest_Successful.snap
@@ -1,0 +1,10 @@
+﻿{
+  "Level": "Professional",
+  "Language": "Java",
+  "Id": "47339b82-ce83-4651-a50a-87340774b17b",
+  "Number": 1989,
+  "LoginName": "oppa",
+  "Name": "Miller",
+  "Firstname": "Ester",
+  "Gender": "female"
+}

--- a/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectOverrideVirtualPropertyOfGrandParentsTest_Successful.snap
+++ b/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectOverrideVirtualPropertyOfGrandParentsTest_Successful.snap
@@ -1,0 +1,10 @@
+﻿{
+  "LoginName": "oppa",
+  "Language": "Java",
+  "Level": "Professional",
+  "Id": "47339b82-ce83-4651-a50a-87340774b17b",
+  "Number": 1989,
+  "Name": "Miller",
+  "Firstname": "Ester",
+  "Gender": "female"
+}

--- a/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectOverrideVirtualPropertyTest_Successful.snap
+++ b/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectOverrideVirtualPropertyTest_Successful.snap
@@ -1,0 +1,10 @@
+﻿{
+  "Level": "Professional",
+  "Language": "Java",
+  "Id": "47339b82-ce83-4651-a50a-87340774b17b",
+  "Number": 1989,
+  "LoginName": "oppa",
+  "Name": "Miller",
+  "Firstname": "Ester",
+  "Gender": "female"
+}

--- a/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectSnapshotTest_Successful.snap
+++ b/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectSnapshotTest_Successful.snap
@@ -1,0 +1,10 @@
+﻿{
+  "Language": "C#",
+  "Level": "Senior",
+  "Id": "7066b471-64c6-4d15-b8f0-19924d200ca9",
+  "Number": 234345,
+  "LoginName": "toddm",
+  "Name": "Smith",
+  "Firstname": "Todd",
+  "Gender": "male"
+}

--- a/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectsSnapshotTest_Successful.snap
+++ b/src/Snapshooter.Xunit.Tests/InheritanceTests/__snapshots__/SnapshotInheritanceTests.Match_InheritedObjectsSnapshotTest_Successful.snap
@@ -1,0 +1,15 @@
+﻿{
+  "person": {
+    "Name": "Brown",
+    "Firstname": "Mike",
+    "Gender": "male"
+  },
+  "employee": {
+    "Id": "47339b82-ce83-4651-a50a-87340774b17b",
+    "Number": 1989,
+    "LoginName": "oppa",
+    "Name": "Miller",
+    "Firstname": "Ester",
+    "Gender": "female"
+  }
+}

--- a/src/Snapshooter.Xunit.Tests/Snapshooter.Xunit.Tests.csproj
+++ b/src/Snapshooter.Xunit.Tests/Snapshooter.Xunit.Tests.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <Folder Include="Asynchronous\__snapshots__\" />
     <Folder Include="Asynchronous\__snapshots__\__mismatch__\" />
+    <Folder Include="InheritanceTests\__snapshots__\__mismatch__\" />
   </ItemGroup>
 
 </Project>

--- a/src/Snapshooter.Xunit.Tests/Snapshooter.Xunit.Tests.csproj
+++ b/src/Snapshooter.Xunit.Tests/Snapshooter.Xunit.Tests.csproj
@@ -41,7 +41,6 @@
   <ItemGroup>
     <Folder Include="Asynchronous\__snapshots__\" />
     <Folder Include="Asynchronous\__snapshots__\__mismatch__\" />
-    <Folder Include="InheritanceTests\__snapshots__\__mismatch__\" />
   </ItemGroup>
 
 </Project>

--- a/src/Snapshooter.sln
+++ b/src/Snapshooter.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2020
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{BC88894B-F8D1-4AB5-9F5A-8D7372F14E2C}"
 EndProject

--- a/src/Snapshooter/Extensions/TypeExtensions.cs
+++ b/src/Snapshooter/Extensions/TypeExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Snapshooter.Core
+{
+    public static class TypeExtensions
+    {
+        public static IEnumerable<Type> BaseTypesAndSelf(this Type type)
+        {
+            while (type != null)
+            {
+                yield return type;
+                type = type.BaseType;
+            }
+        }
+    }
+}

--- a/src/Snapshooter/Extensions/TypeExtensions.cs
+++ b/src/Snapshooter/Extensions/TypeExtensions.cs
@@ -3,8 +3,16 @@ using System.Collections.Generic;
 
 namespace Snapshooter.Core
 {
+    /// <summary>
+    /// Some extensions for Type, to support snapshot testing.
+    /// </summary>
     public static class TypeExtensions
     {
+        /// <summary>
+        /// Returns the list of inherited types.
+        /// </summary>
+        /// <param name="type">The current object type.</param>
+        /// <returns>The list of all inherited types.</returns>
         public static IEnumerable<Type> BaseTypesAndSelf(this Type type)
         {
             while (type != null)


### PR DESCRIPTION
In very rare cases, the Newtonsoft Json serializer puts the parent properties in front of child properties. If this happens, then the order of the properties is wrong, because the default ordering is 'child properties first'. We added a correction, which guarantees child properties first.
