### PR TITLE
Changed snapshot namesto culture info invariant and ISO8601

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,10 @@ trim_trailing_whitespace = false
 # CSharp code style settings:
 [*.cs]root = true
 
+# C# or VB files
+[*.{cs,vb}]
+guidelines = 80, 100
+
 [*]
 charset = utf-8
 end_of_line = lf

--- a/src/Snapshooter.Tests/SnapshotNameExtensionTests.cs
+++ b/src/Snapshooter.Tests/SnapshotNameExtensionTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using Xunit;
+
+namespace Snapshooter
+{
+    public class SnapshotNameExtensionTests
+    {
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("en-GB")]
+        [InlineData("de-DE")]
+        [InlineData("fr-FR")]
+        [InlineData("it-IT")]
+        [InlineData("ru-RU")]
+        [InlineData("it-CH")]
+        [InlineData("de-AT")]
+        [InlineData("en-AU")]
+        [InlineData("de-LU")]
+        [InlineData("en-NZ")]
+        [InlineData("es-ES")]
+        [InlineData("es-CR")]
+        public void ToParamsString_InDifferentCultures_CreatedNameExtensionsSuccessfully(
+            string cultureName)
+        {
+            // arrange
+            string nameExtension = string.Empty;
+
+            var thread = new Thread(new ThreadStart(() =>
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
+
+                var snapshotNameExtension = SnapshotNameExtension.Create(
+                "bool", true,
+                "char", 'b',
+                "byte", (byte)255,
+                "sbyte", (sbyte)127,
+                "float", 789.6655f,
+                "double", 45.987d,
+                "decimal", 7834.99000944m,
+                "integer", -159485,
+                "long", 9223372036854775807,
+                "guid", Guid.Parse("{CA9C1C14-839A-4ED2-9763-01FB68FDF49D}"),
+                "enum", Importance.Regular,
+                "dateTime", DateTime.ParseExact(
+                    "12.01.2009 17:05:34", "dd.MM.yyyy HH:mm:ss", CultureInfo.CurrentCulture),
+                "dateTimeOffset", DateTimeOffset.ParseExact(
+                    "10/21/2020 18:34 +05:00", "MM/dd/yyyy HH:mm zzz", CultureInfo.CurrentCulture)
+                );
+
+                nameExtension = snapshotNameExtension.ToParamsString();
+            }));
+
+            // act
+            thread.Start();
+            thread.Join();
+            
+            // assert
+            Assert.Equal(
+                "_bool_True" +
+                "_char_b" +
+                "_byte_255" +
+                "_sbyte_127" +
+                "_float_789.6655" +
+                "_double_45.987" +
+                "_decimal_7834.99000944" +
+                "_integer_-159485" +
+                "_long_9223372036854775807" +
+                "_guid_ca9c1c14-839a-4ed2-9763-01fb68fdf49d" +
+                "_enum_Regular" +
+                "_dateTime_2009-01-12T17:05:34Z" +
+                "_dateTimeOffset_2020-10-21T18:34:00Z",
+                nameExtension);
+        }
+        
+        private enum Importance
+        {
+            Regular
+        }
+    }
+}

--- a/src/Snapshooter/Extensions/MethodBaseExtension.cs
+++ b/src/Snapshooter/Extensions/MethodBaseExtension.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Globalization;
+using System.Reflection;
 
 namespace Snapshooter.Extensions
 {
@@ -15,7 +16,8 @@ namespace Snapshooter.Extensions
         public static string ToName(this MethodBase methodBase)
         {
             var fullName = string.Concat(
-                methodBase.ReflectedType.Name, ".", methodBase.Name);
+                methodBase.ReflectedType.Name.ToString(CultureInfo.InvariantCulture), ".", 
+                methodBase.Name.ToString(CultureInfo.InvariantCulture));
 
             return fullName;
         }

--- a/src/Snapshooter/SnapshotNameExtension.cs
+++ b/src/Snapshooter/SnapshotNameExtension.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 
 namespace Snapshooter
 {
@@ -69,13 +72,31 @@ namespace Snapshooter
         /// </summary>
         /// <returns>The snapshot name extension text.</returns>
         public string ToParamsString()
-        {            
-            string extensionName = string.Join("_", _snapshotNameExtensions);
+        {
+            string extensionName = string.Join("_",
+                _snapshotNameExtensions.Select(obj => { return ConvertParameter(obj); }));
+
             if (!string.IsNullOrWhiteSpace(extensionName))
             {
                 extensionName = string.Concat("_", extensionName);
             }
-            return extensionName;            
+
+            return extensionName;
+        }
+
+        private static string ConvertParameter(object obj)
+        {
+            if (obj is DateTime dateTime)
+            {
+                return dateTime.ToString("yyyy-MM-ddTHH:mm:ssZ");
+            }
+
+            if (obj is DateTimeOffset dateTimeOffset)
+            {
+                return dateTimeOffset.ToString("yyyy-MM-ddTHH:mm:ssZ");
+            }
+
+            return Convert.ToString(obj, CultureInfo.InvariantCulture);
         }
     }
 }


### PR DESCRIPTION
The snapshot name extensions converted the objects (double, float, datetime) always with the current culture settings. This caused inconsistent snapshot names between systems. To solve this, we changed the snapshot name extension conversion to culture invariant and the date time to ISO8601.
Fixes #77
