### PR TITLE
breaking: make unwanted method internal

### DIFF
--- a/src/Snapshooter/Helpers/ObjectWrapperRemover.cs
+++ b/src/Snapshooter/Helpers/ObjectWrapperRemover.cs
@@ -5,7 +5,7 @@ namespace Snapshooter
 {
     public static class ObjectWrapperRemover
     {
-        public static object RemoveUnwantedWrappers(this object objectToRemoveWrappers)
+        internal static object RemoveUnwantedWrappers(this object objectToRemoveWrappers)
         {
             if (objectToRemoveWrappers == null)
             {

--- a/src/Snapshooter/InternalsVisibleTo.cs
+++ b/src/Snapshooter/InternalsVisibleTo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Snapshooter.NUnit")]
+[assembly: InternalsVisibleTo("Snapshooter.XUnit")]


### PR DESCRIPTION
The extension method `ObjectWrapperRemover.RemoveUnwantedWrappers` is public 
This extension method extends object and therefor is displayed by intellisense on _every_ object

# Breaking Change
This change is technically breaking. So in terms of semver this should probably wait for the next major release

