### PR TITLE
Be less strict on detection of FluentAssertions types

### DIFF
--- a/src/Snapshooter.NUnit.Tests/SnapshotExtensionTests.cs
+++ b/src/Snapshooter.NUnit.Tests/SnapshotExtensionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using NUnit.Framework;
 using Snapshooter.Tests.Data;
@@ -25,6 +26,36 @@ namespace Snapshooter.NUnit.Tests
 
             // act & assert
             testPerson.Should().MatchSnapshot(nameof(MatchSnapshot_ShouldFluentAssertionsNameOf_RemovesSubject));
+        }
+
+        [Test(Description = "Test for issue #118")]
+        public void MatchSnapshot_FluentAssertions_StringValue_ShouldRemovesSubject()
+        {
+            // arrange
+            string testValue = "Some text string";
+
+            // act & assert
+            testValue.Should().MatchSnapshot();
+        }
+
+        [Test(Description = "Test for issue #118")]
+        public void MatchSnapshot_FluentAssertions_DictionaryValue_ShouldRemovesSubject()
+        {
+            // arrange
+            var testCustomer = new List<Dictionary<string, object>>
+            {
+                new Dictionary<string, object>
+                {
+                    { "Id", 1 },
+                    { "Name", "Bla "},
+                    { "EmailAddress", "blabla@blabla.com" },
+                },
+            };
+            var testDictionary = new Dictionary<string, List<Dictionary<string, object>>>();
+            testDictionary.Add("Customer", testCustomer);
+
+            // act & assert
+            testDictionary.Should().MatchSnapshot();
         }
 
         [Test]

--- a/src/Snapshooter.NUnit.Tests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_FluentAssertions_DictionaryValue_ShouldRemovesSubject.snap
+++ b/src/Snapshooter.NUnit.Tests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_FluentAssertions_DictionaryValue_ShouldRemovesSubject.snap
@@ -1,0 +1,9 @@
+﻿{
+  "Customer": [
+    {
+      "Id": 1,
+      "Name": "Bla ",
+      "EmailAddress": "blabla@blabla.com"
+    }
+  ]
+}

--- a/src/Snapshooter.NUnit.Tests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_FluentAssertions_StringValue_ShouldRemovesSubject.snap
+++ b/src/Snapshooter.NUnit.Tests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_FluentAssertions_StringValue_ShouldRemovesSubject.snap
@@ -1,0 +1,1 @@
+﻿Some text string

--- a/src/Snapshooter/Helpers/ObjectWrapperRemover.cs
+++ b/src/Snapshooter/Helpers/ObjectWrapperRemover.cs
@@ -26,11 +26,11 @@ namespace Snapshooter
 
             PropertyInfo prop = resultType.GetProperty("Subject");
             if (prop == null)
+            {
                 return objectToRemoveWrappers;
+            }
 
-            object actualvalue = prop.GetValue(objectToRemoveWrappers);
-
-            return actualvalue;
+            return prop.GetValue(objectToRemoveWrappers);
         }
     }
 }

--- a/src/Snapshooter/Helpers/ObjectWrapperRemover.cs
+++ b/src/Snapshooter/Helpers/ObjectWrapperRemover.cs
@@ -12,25 +12,23 @@ namespace Snapshooter
                 throw new ArgumentNullException(nameof(objectToRemoveWrappers));
             }
 
-            return objectToRemoveWrappers.RemoveFluentAssertionWrapper();
+            return objectToRemoveWrappers.RemoveFluentAssertionsWrapper();
         }
 
-        private static object RemoveFluentAssertionWrapper(this object objectToRemoveWrappers)
+        private static object RemoveFluentAssertionsWrapper(this object objectToRemoveWrappers)
         {
             Type resultType = objectToRemoveWrappers.GetType();
 
-            if (resultType.Namespace != null
-                && resultType.Name != null
-                && resultType.Namespace.Equals("FluentAssertions.Primitives")
-                && resultType.Name.Equals("ObjectAssertions"))
-            {
-                PropertyInfo prop = resultType.GetProperty("Subject");
-                object actualvalue = prop.GetValue(objectToRemoveWrappers);
+            if (resultType.Namespace == null || !resultType.Namespace.StartsWith("FluentAssertions."))
+                return objectToRemoveWrappers;
 
-                return actualvalue;
-            }
+            PropertyInfo prop = resultType.GetProperty("Subject");
+            if (prop == null)
+                return objectToRemoveWrappers;
 
-            return objectToRemoveWrappers;
+            object actualvalue = prop.GetValue(objectToRemoveWrappers);
+
+            return actualvalue;
         }
     }
 }

--- a/src/Snapshooter/Helpers/ObjectWrapperRemover.cs
+++ b/src/Snapshooter/Helpers/ObjectWrapperRemover.cs
@@ -20,7 +20,9 @@ namespace Snapshooter
             Type resultType = objectToRemoveWrappers.GetType();
 
             if (resultType.Namespace == null || !resultType.Namespace.StartsWith("FluentAssertions."))
+            {
                 return objectToRemoveWrappers;
+            }
 
             PropertyInfo prop = resultType.GetProperty("Subject");
             if (prop == null)


### PR DESCRIPTION
Make the method `RemoveFluentAssertionsWrapper` less strict on which assertion types it supports. This will make `MatchSnapshot` also work when using FluentAssertions on primitive types like `string` or `Dictionary<>`.

Addresses #118 
