### PR TITLE
125 0.6.0 throws ReflectionTypeLoadException | Could not load file or assembly Microsoft.VisualStudio.Coverage.CoreLib.Net Version=16.9.0.0

### DIFF
--- a/src/Snapshooter.Json.Tests/Snapshooter.Json.Tests.csproj
+++ b/src/Snapshooter.Json.Tests/Snapshooter.Json.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Snapshooter.NUnit.Tests/Snapshooter.NUnit.Tests.csproj
+++ b/src/Snapshooter.NUnit.Tests/Snapshooter.NUnit.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
   </ItemGroup>

--- a/src/Snapshooter.Tests/Snapshooter.Tests.csproj
+++ b/src/Snapshooter.Tests/Snapshooter.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Snapshooter.Xunit.Tests/Snapshooter.Xunit.Tests.csproj
+++ b/src/Snapshooter.Xunit.Tests/Snapshooter.Xunit.Tests.csproj
@@ -24,7 +24,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Snapshooter/Core/Serialization/GlobalSnapshotSettingsResolver.cs
+++ b/src/Snapshooter/Core/Serialization/GlobalSnapshotSettingsResolver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Snapshooter.Core.Serialization
 {
@@ -11,10 +12,20 @@ namespace Snapshooter.Core.Serialization
             Type type = typeof(SnapshotSerializerSettings);
 
             var typesExtendingSettings = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(s => s.GetTypes())
-                .Where(p => 
-                    type.IsAssignableFrom(p) && 
-                    p.IsClass && 
+                .SelectMany(s =>
+                {
+                    try
+                    {
+                        return s.GetTypes();
+                    }
+                    catch (ReflectionTypeLoadException e)
+                    {
+                        return e.Types;
+                    }
+                })
+                .Where(p =>
+                    type.IsAssignableFrom(p) &&
+                    p.IsClass &&
                     p.GetConstructor(Type.EmptyTypes) != null)
                 .ToList();
 


### PR DESCRIPTION
Catch ReflectionTypeLoadException on Assembly.GetTypes https://github.com/SwissLife-OSS/snapshooter/commit/fbfd5159a8d1daa65239a606c2eb5fc184db8a21

Addresses #125

I also updated Microsoft.NET.Test.Sdk to 16.9.1 (2a991a4) that reproduces the issue on the tests without the fbfd515 fix .