### PR TITLE
resest snapshotName on Exceptions

### DIFF
--- a/src/Snapshooter.Tests/Core/JsonSerializerTests.cs
+++ b/src/Snapshooter.Tests/Core/JsonSerializerTests.cs
@@ -33,7 +33,6 @@ namespace Snapshooter.Tests.Core
         private enum MyEnum
         {
             FirstValue = 1,
-            // ReSharper disable once UnusedMember.Local
             SecondValue = 2,
             LastValue = 99
         }

--- a/src/Snapshooter.Xunit/Snapshot.cs
+++ b/src/Snapshooter.Xunit/Snapshot.cs
@@ -255,8 +255,14 @@ namespace Snapshooter.Xunit
             SnapshotFullName snapshotFullName,
             Func<MatchOptions, MatchOptions> matchOptions = null)
         {
-            Snapshooter.AssertSnapshot(currentResult, snapshotFullName, matchOptions);
-            _snapshotName = new AsyncLocal<SnapshotFullName>();
+            try
+            {
+                Snapshooter.AssertSnapshot(currentResult, snapshotFullName, matchOptions);
+            }
+            finally
+            {
+                _snapshotName = new AsyncLocal<SnapshotFullName>();
+            }
         }
 
         /// <summary>

--- a/src/Snapshooter.Xunit/Snapshot.cs
+++ b/src/Snapshooter.Xunit/Snapshot.cs
@@ -153,8 +153,14 @@ namespace Snapshooter.Xunit
             object currentResult,
             Func<MatchOptions, MatchOptions> matchOptions = null)
         {
-            Snapshooter.AssertSnapshot(currentResult, FullName(), matchOptions);
-            _snapshotName = new AsyncLocal<SnapshotFullName>();
+            try
+            {
+                Snapshooter.AssertSnapshot(currentResult, FullName(), matchOptions);
+            }
+            finally
+            {
+                _snapshotName = new AsyncLocal<SnapshotFullName>();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Reseting "_snapshotName" when there is an Exception

till now it fails when running multiple Snaptshots and one of them has a missmatch, all the others will fail too...