### PR TITLE
Add support for NUnit `TestCaseSource` attribute

### DIFF
--- a/src/Snapshooter.NUnit.Tests/NUnitSnapshotFullNameReaderTests.cs
+++ b/src/Snapshooter.NUnit.Tests/NUnitSnapshotFullNameReaderTests.cs
@@ -79,6 +79,49 @@ namespace Snapshooter.NUnit.Tests
                 $"_{param1}_{param2}"));
         }
 
+        [TestCaseSource(nameof(TestCases))]
+        public void ReadSnapshotFullName_ResolveTheoryDataSnapshotName_NameResolvedWithoutInlineDataParameters(
+           string param1, int param2)
+        {
+            // arrange
+            var snapshotFullNameResolver = new NUnitSnapshotFullNameReader();
+
+            // act
+            SnapshotFullName snapshotFullName = snapshotFullNameResolver.ReadSnapshotFullName();
+
+            // assert
+            Assert.That(snapshotFullName.Filename, Is.EqualTo(
+                $"{nameof(NUnitSnapshotFullNameReaderTests)}." +
+                $"{nameof(ReadSnapshotFullName_ResolveTheoryDataSnapshotName_NameResolvedWithoutInlineDataParameters)}" +
+                $"_{param1}_{param2}"));
+        }
+
+        [TestCaseSource(nameof(TestCases))]
+        public async Task ReadSnapshotFullName_ResolveTheoryDataSnapshotNameAsync_NameResolvedWithoutInlineDataParameters(
+           string param1, int param2)
+        {
+            // arrange
+            var snapshotFullNameResolver = new NUnitSnapshotFullNameReader();
+            await Task.Delay(1);
+
+            // act
+            SnapshotFullName snapshotFullName = snapshotFullNameResolver.ReadSnapshotFullName();
+
+            // assert
+            await Task.Delay(1);
+            Assert.That(snapshotFullName.Filename, Is.EqualTo(
+                $"{nameof(NUnitSnapshotFullNameReaderTests)}." +
+                $"{nameof(ReadSnapshotFullName_ResolveTheoryDataSnapshotNameAsync_NameResolvedWithoutInlineDataParameters)}" +
+                $"_{param1}_{param2}"));
+        }
+
+        private static object[] TestCases => new object[]
+        {
+            new object[] { "testString1", 5 },
+            new object[] { "testString2", 6 },
+            new object[] { "testString3", 7 }
+        };
+
         #pragma warning restore xUnit1026 // Theory methods should use all of their parameters
     }
 }

--- a/src/Snapshooter.NUnit/NUnitSnapshotFullNameReader.cs
+++ b/src/Snapshooter.NUnit/NUnitSnapshotFullNameReader.cs
@@ -72,8 +72,9 @@ namespace Snapshooter.NUnit
         {
             bool isFactTest = IsTestMethod(method);
             bool isTheoryTest = IsTestCaseTestMethod(method);
+            bool isTheoryDataTest = IsTestCaseSourceTestMethod(method);
 
-            return isFactTest || isTheoryTest;
+            return isFactTest || isTheoryTest || isTheoryDataTest;
         }
 
         private static bool IsTestMethod(MemberInfo method)
@@ -84,6 +85,11 @@ namespace Snapshooter.NUnit
         private static bool IsTestCaseTestMethod(MemberInfo method)
         {
             return method?.GetCustomAttributes(typeof(TestCaseAttribute))?.Any() ?? false;
+        }
+
+        private static bool IsTestCaseSourceTestMethod(MemberInfo method)
+        {
+            return method?.GetCustomAttributes(typeof(TestCaseSourceAttribute))?.Any() ?? false;
         }
 
         private static MethodBase EvaluateAsynchronMethodBase(MemberInfo method)


### PR DESCRIPTION
Add support for name generation when tests have `TestCaseSource` attribute

Summary of the changes (Less than 80 chars)

- Handle the case when the tests use `TestCaseSourceAttribute` to generate snapshot names
- Add tests

Addresses #145 (in this specific format)
