### PR TITLE
Add support for lambda expressions instead of json path for ignore and accept

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,35 @@ Option 2: Use the default ignore match option 'IgnoreFields(**.<fieldName>)' wit
 Snapshot.Match<Person>(person, matchOptions => matchOptions.IgnoreFields("**.Id"));
 ```
 
+#### Ignore using a lambda expression
+
+We also support ignoring fields using lambda expressions instead of json paths.
+
+```csharp
+// Ignores the Id field of the person
+Snapshot.Match<Person>(person, matchOptions => matchOptions.IgnoreField(person => person.Id));
+```
+
+### Assert the type of a field but ignore its value
+
+Using the `.AcceptField()` and `.AcceptFields()` syntax we can assert that a certain field contains a value of a given type.
+Unlike ignore the snapshot file will not contain the field value but instead the type assertion, for example: `"Field": "AcceptAny<String>"`.
+This is desirable because the snapshot will not change when it is recreated at a later time.
+
+#### Example with json path syntax
+
+```csharp
+// Assert that the id field is a guid and writes "AcceptAny<Guid>" into the snapshot file
+Snapshot.Match<Person>(person, matchOptions => matchOptions.AcceptField<Guid>("id"));
+```
+
+#### Examle with lambda expressions
+
+```csharp
+// Assert that the id field is a guid and writes "AcceptAny<Guid>" into the snapshot file
+Snapshot.Match<Person>(person, matchOptions => matchOptions.AcceptField(person => person.Id));
+```
+
 ### Assert Fields in Snapshots Matches
 
 Sometimes there are fields in a snapshot, which you want to assert separately against another value.

--- a/src/Snapshooter.Json.Tests/SnapshotTests.cs
+++ b/src/Snapshooter.Json.Tests/SnapshotTests.cs
@@ -199,6 +199,19 @@ namespace Snapshooter.Json.Tests
             Assert.True(File.Exists(snapshotFileName));
         }
 
+        [Fact]
+        public void Match_WithLambdaExpression_Works()
+        {
+            // arrange
+            string snapshotName = nameof(SnapshotTests) + "." +
+                                  nameof(Match_FactMatchSingleSnapshot_GoodCase);
+
+            TestPerson testPerson = TestDataBuilder.TestPersonMarkWalton().Build();
+
+            // act & assert
+            Snapshot.Match(testPerson, snapshotName, o => o.AcceptField(p => p.Age));
+        }
+
         #endregion
 
         #region Match Snapshot - Multiple Objects Tests

--- a/src/Snapshooter.Json/Snapshot.cs
+++ b/src/Snapshooter.Json/Snapshot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Snapshooter.Core;
 using Snapshooter.Core.Serialization;
 
@@ -26,11 +26,15 @@ namespace Snapshooter.Json
         /// <param name="matchOptions">
         /// Additional compare actions, which can be applied during the comparison
         /// </param>
-        public static void Match<T>(T currentResult,
-                                    string snapshotName,
-                                    Func<MatchOptions, MatchOptions> matchOptions = null)
+        public static void Match<T>(
+            T currentResult,
+            string snapshotName,
+            Func<MatchOptions<T>, MatchOptions<T>> matchOptions = null)
         {
-            Match((object)currentResult, snapshotName, matchOptions);
+            Match(
+                (object)currentResult,
+                snapshotName,
+                o => matchOptions == null ? o : matchOptions(new MatchOptions<T>(o)));
         }
 
         /// <summary>
@@ -56,12 +60,17 @@ namespace Snapshooter.Json
         /// <param name="matchOptions">
         /// Additional compare actions, which can be applied during the comparison
         /// </param>
-        public static void Match<T>(T currentResult,
-                                    string snapshotName,
-                                    SnapshotNameExtension snapshotNameExtension,
-                                    Func<MatchOptions, MatchOptions> matchOptions = null)
+        public static void Match<T>(
+            T currentResult,
+            string snapshotName,
+            SnapshotNameExtension snapshotNameExtension,
+            Func<MatchOptions<T>, MatchOptions<T>> matchOptions = null)
         {
-            Match((object)currentResult, snapshotName, snapshotNameExtension, matchOptions);
+            Match(
+                (object)currentResult,
+                snapshotName,
+                snapshotNameExtension,
+                o => matchOptions == null ? o : matchOptions(new MatchOptions<T>(o)));
         }
 
         /// <summary>

--- a/src/Snapshooter.NUnit.Tests/SnapshotExtensionTests.cs
+++ b/src/Snapshooter.NUnit.Tests/SnapshotExtensionTests.cs
@@ -97,5 +97,18 @@ namespace Snapshooter.NUnit.Tests
             // act & assert
             Assert.Throws<ArgumentNullException>(() => testPerson.MatchSnapshot());
         }
+
+        [Test]
+        public void MatchSnapshot_ShouldFluentAssertionsWithLambda_RemovesSubject()
+        {
+            // arrange
+            TestPerson testPerson = TestDataBuilder.TestPersonMarkWalton().Build();
+
+            // act & assert
+            testPerson.Should().MatchSnapshot(o => o
+                .AcceptField(m => m.Firstname)
+                .AcceptField(m => m.DateOfBirth)
+                .IgnoreFields(m => m.Children['*'].Name));
+        }
     }
 }

--- a/src/Snapshooter.NUnit.Tests/SnapshotTests.cs
+++ b/src/Snapshooter.NUnit.Tests/SnapshotTests.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using NUnit.Framework;
 using Snapshooter.Tests.Data;
 
@@ -130,6 +130,16 @@ namespace Snapshooter.NUnit.Tests
 
             // assert
             Assert.True(File.Exists(snapshotFileName));
+        }
+
+        [Test]
+        public void Match_WithLambdaExpression_Works()
+        {
+            // arrange
+            TestPerson testPerson = TestDataBuilder.TestPersonMarkWalton().Build();
+
+            // act & assert
+            Snapshot.Match(testPerson, o => o.AcceptField(t => t.Age));
         }
 
         #endregion

--- a/src/Snapshooter.NUnit.Tests/__snapshots__/SnapshotTests.Match_WithLambdaExpression_Works.snap
+++ b/src/Snapshooter.NUnit.Tests/__snapshots__/SnapshotTests.Match_WithLambdaExpression_Works.snap
@@ -1,0 +1,56 @@
+﻿{
+  "Id": "c78c698f-9ee5-4b4b-9a0e-ef729b1f8ec8",
+  "Firstname": "Mark",
+  "Lastname": "Walton",
+  "CreationDate": "2018-06-06T00:00:00",
+  "DateOfBirth": "2000-06-25T00:00:00",
+  "Age": "AcceptAny<Integer?>",
+  "Size": 182.5214,
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  },
+  "Children": [
+    {
+      "Name": "James",
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": null,
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": "Hanna",
+      "DateOfBirth": "2012-03-20T00:00:00"
+    }
+  ],
+  "Relatives": [
+    {
+      "Id": "fcf04ca6-d8f2-4214-a3ff-d0ded5bad4de",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Size": 165.23,
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      },
+      "Children": [],
+      "Relatives": null
+    }
+  ]
+}

--- a/src/Snapshooter.NUnit/Snapshot.cs
+++ b/src/Snapshooter.NUnit/Snapshot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using Snapshooter.Core;
 using Snapshooter.Core.Serialization;
@@ -30,9 +30,11 @@ namespace Snapshooter.NUnit
         /// </param>
         public static void Match<T>(
             T currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions<T>, MatchOptions<T>> matchOptions = null)
         {
-            Match((object)currentResult, matchOptions);
+            Match(
+                (object)currentResult,
+                o => matchOptions == null ? o : matchOptions(new MatchOptions<T>(o)));
         }
 
         /// <summary>
@@ -58,9 +60,12 @@ namespace Snapshooter.NUnit
         public static void Match<T>(
             T currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions<T>, MatchOptions<T>> matchOptions = null)
         {
-            Match((object)currentResult, snapshotNameExtension, matchOptions);
+            Match(
+                (object)currentResult,
+                snapshotNameExtension,
+                o => matchOptions == null ? o : matchOptions(new MatchOptions<T>(o)));
         }
 
         /// <summary>
@@ -81,9 +86,12 @@ namespace Snapshooter.NUnit
         public static void Match<T>(
             T currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions<T>, MatchOptions<T>> matchOptions = null)
         {
-            Match((object)currentResult, snapshotName, matchOptions);
+            Match(
+                (object)currentResult,
+                snapshotName,
+                o => matchOptions == null ? o : matchOptions(new MatchOptions<T>(o)));
         }
 
         /// <summary>
@@ -114,9 +122,13 @@ namespace Snapshooter.NUnit
             T currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions<T>, MatchOptions<T>> matchOptions = null)
         {
-            Match((object)currentResult, snapshotName, snapshotNameExtension, matchOptions);
+            Match(
+                (object)currentResult,
+                snapshotName,
+                snapshotNameExtension,
+                o => matchOptions == null ? o : matchOptions(new MatchOptions<T>(o)));
         }
 
         /// <summary>
@@ -134,9 +146,12 @@ namespace Snapshooter.NUnit
         public static void Match<T>(
             T currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions<T>, MatchOptions<T>> matchOptions = null)
         {
-            Match((object)currentResult, snapshotFullName, matchOptions);
+            Match(
+                (object)currentResult,
+                snapshotFullName,
+                o => matchOptions == null ? o : matchOptions(new MatchOptions<T>(o)));
         }
 
         /// <summary>

--- a/src/Snapshooter.NUnit/SnapshotExtension.cs
+++ b/src/Snapshooter.NUnit/SnapshotExtension.cs
@@ -1,4 +1,5 @@
 using System;
+using FluentAssertions;
 
 namespace Snapshooter.NUnit
 {
@@ -126,6 +127,30 @@ namespace Snapshooter.NUnit
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotFullName, matchOptions);
+        }
+
+        /// <summary>
+        /// Creates a json snapshot of the given object and compares it with the
+        /// already existing snapshot of the test.
+        /// If no snapshot exists, a new snapshot will be created from the current result
+        /// and saved under a certain file path, which will shown within the test message.
+        /// </summary>
+        /// <param name="currentResult">The object to match.</param>
+        /// <param name="matchOptions">
+        /// Additional compare actions, which can be applied during the snapshot comparison
+        /// </param>
+        public static void MatchSnapshot<TSubject>(
+            this TypedAssertions<TSubject> currentResult,
+            Func<MatchOptions<TSubject>, MatchOptions<TSubject>>? matchOptions = null)
+        {
+            var cleanedObject = currentResult.RemoveUnwantedWrappers();
+
+            Func<MatchOptions, MatchOptions>? chainedMatchOptions =
+                matchOptions != null ? m => matchOptions(new MatchOptions<TSubject>(m)) : null;
+
+            Snapshot.Match(
+                cleanedObject,
+                chainedMatchOptions);
         }
     }
 }

--- a/src/Snapshooter.Tests.Data/TestPerson.cs
+++ b/src/Snapshooter.Tests.Data/TestPerson.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -19,7 +19,7 @@ namespace Snapshooter.Tests.Data
         public int? Age { get; set; }
         public decimal? Size { get; set; }
         public TestAddress Address { get; set; }
-        public IEnumerable<TestChild> Children { get; set; }
+        public IList<TestChild> Children { get; set; }
         public TestPerson[] Relatives { get; set; }
     }
 

--- a/src/Snapshooter.Tests/Helpers/LambdaPathTests.cs
+++ b/src/Snapshooter.Tests/Helpers/LambdaPathTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Snapshooter.Helpers;
+using Xunit;
+using System.Linq;
+using FluentAssertions;
+using Snapshooter.Exceptions;
+using TupleList = System.Collections.Generic.List<System.Tuple<string, System.Linq.Expressions.Expression<System.Func<Snapshooter.Tests.Helpers.Model, object>>>>;
+
+
+namespace Snapshooter.Tests.Helpers
+{
+    public class LambdaPathTests
+    {
+        public static IEnumerable<object[]> Data() =>
+            new TupleList
+            {
+                new(
+                    "FooBar",
+                    m => m.FooBar),
+                new(
+                    "Foo.Id",
+                    m => m.Foo.Id),
+                new(
+                    "NestedType.MoreNesting.EvenMore.Field",
+                    m => m.NestedType.MoreNesting.EvenMore.Field),
+                new(
+                    "Bars[0].Name",
+                    m => m.Bars[0].Name),
+                new(
+                    "NestedType.MoreNestingList[0].EvenMoreArray[0].Field",
+                    m => m.NestedType.MoreNestingList[0].EvenMoreArray[0].Field),
+                new(
+                    "Bars[*].Name",
+                    m => m.Bars['*'].Name),
+                new(
+                    "NestedType.MoreNestingList[*].EvenMoreArray[*].Field",
+                    m => m.NestedType.MoreNestingList[-1].EvenMoreArray['*'].Field),
+                new(
+                    "WithoutGetSet.MoreNesting.EvenMore.Field",
+                    m => m.WithoutGetSet.MoreNesting.EvenMore.Field),
+            }.Select(t => new object[] { t.Item2, t.Item1 });
+
+
+        [Theory]
+        [MemberData(nameof(Data))]
+        public void LambdaPath_ValidExpression_CorrectJsonPath(
+            Expression<Func<Model, object>> expression,
+            string expected)
+        {
+            Assert.Equal(expected, LambdaPath<Model>.Get(expression));
+        }
+
+        [Fact]
+        public void LambdaPath_InvalidExpression_Exception()
+        {
+            // Act
+            Action action = () => LambdaPath<Model>.Get(m => m.IAmAFunction());
+
+            // Assert
+            action.Should().Throw<LambdaPathConversionException>();
+        }
+    }
+
+    public class Model
+    {
+        public Foo Foo { get; set; }
+        public IList<Bar> Bars { get; set; }
+
+        public string FooBar { get; set; }
+
+        public NestedType NestedType { get; set; }
+
+        public NestedType WithoutGetSet;
+
+        public bool IAmAFunction()
+        {
+            return false;
+        }
+    }
+
+    public class NestedType
+    {
+        public MoreNesting MoreNesting { get; set; }
+        public List<MoreNesting> MoreNestingList { get; set; }
+    }
+
+    public class MoreNesting
+    {
+        public EvenMore EvenMore { get; set; }
+        public EvenMore[] EvenMoreArray { get; set; }
+    }
+
+    public class EvenMore
+    {
+        public Guid Field { get; set; }
+    }
+
+    public class Bar
+    {
+        public string Name { get; set; }
+    }
+
+    public class Foo
+    {
+        public int Id { get; set; }
+    }
+}

--- a/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/SnapshotExtensionTests.cs
+++ b/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/SnapshotExtensionTests.cs
@@ -1,5 +1,5 @@
 using System;
-using FluentAssertions.Primitives;
+using FluentAssertions;
 using Snapshooter.Tests.Data;
 using Xunit;
 

--- a/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/SnapshotExtensionTests.cs
+++ b/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/SnapshotExtensionTests.cs
@@ -1,29 +1,6 @@
-using System;
-using System.Linq;
-using System.Linq.Expressions;
 using FluentAssertions.Primitives;
-using Snapshooter.Helpers;
 using Snapshooter.Tests.Data;
 using Xunit;
-
-// Extension of Fluent assertion to not loose type information of asserted object
-namespace FluentAssertions.Primitives
-{
-    public class TypedAssertions<T> : ObjectAssertions<T, TypedAssertions<T>>
-    {
-        public TypedAssertions(T value) : base(value)
-        {
-        }
-    }
-
-    public static class Extensions
-    {
-        public static TypedAssertions<TSubject> Should<TSubject>(this TSubject actualValue)
-        {
-            return new TypedAssertions<TSubject>(actualValue);
-        }
-    }
-}
 
 namespace Snapshooter.Xunit.Tests.LambdaExpressionsTests
 {
@@ -40,50 +17,6 @@ namespace Snapshooter.Xunit.Tests.LambdaExpressionsTests
                 .AcceptField(m => m.Firstname)
                 .AcceptField(m => m.DateOfBirth)
                 .IgnoreFields(m => m.Children['*'].Name));
-        }
-    }
-
-    public static class Extensions
-    {
-        public static void MatchSnapshot<TSubject>(
-            this TypedAssertions<TSubject> currentResult,
-            Func<MatchOptions<TSubject>, MatchOptions<TSubject>>? matchOptions = null)
-        {
-            var cleanedObject = currentResult.RemoveUnwantedWrappers();
-
-            Func<MatchOptions, MatchOptions>? chainedMatchOptions =
-                matchOptions != null ? m => matchOptions(new MatchOptions<TSubject>(m)) : null;
-
-            Snapshot.Match(
-                cleanedObject,
-                chainedMatchOptions);
-        }
-    }
-
-    /// <summary>
-    /// MatchOption which also knows the type of the object we assert against.
-    /// </summary>
-    public class MatchOptions<TModel> : MatchOptions
-    {
-        public MatchOptions(MatchOptions predecessor)
-        {
-            _matchOperators = predecessor.MatchOperators.ToList();
-        }
-
-        public MatchOptions<TModel> AcceptField<TU>(Expression<Func<TModel, TU>> fieldPath)
-        {
-            var path = LambdaPath<TModel>.Get(fieldPath);
-            Accept<TU>(path);
-
-            return this;
-        }
-
-        public MatchOptions<TModel> IgnoreFields<TU>(Expression<Func<TModel, TU>> fieldPaths)
-        {
-            var path = LambdaPath<TModel>.Get(fieldPaths);
-            IgnoreFields<TU>(path);
-
-            return this;
         }
     }
 }

--- a/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/SnapshotExtensionTests.cs
+++ b/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/SnapshotExtensionTests.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using FluentAssertions.Primitives;
+using Snapshooter.Helpers;
 using Snapshooter.Tests.Data;
 using Xunit;
 
@@ -85,72 +84,6 @@ namespace Snapshooter.Xunit.Tests.LambdaExpressionsTests
             IgnoreFields<TU>(path);
 
             return this;
-        }
-    }
-
-    /// <summary>
-    /// Converts a Lambda Expression into a JsonPath
-    /// </summary>
-    /// <typeparam name="TSource"></typeparam>
-    public static class LambdaPath<TSource>
-    {
-        public static string Get<TResult>(Expression<Func<TSource, TResult>> expression)
-        {
-            var visitor = new PathPrintVisitor();
-            visitor.Visit(expression.Body);
-            visitor.Path.Reverse();
-            return string.Join("", visitor.Path)
-                .Substring(1);
-        }
-
-        private class PathPrintVisitor : ExpressionVisitor
-        {
-            internal readonly List<string> Path = new();
-
-            protected override Expression VisitMember(MemberExpression node)
-            {
-                if (!(node.Member is PropertyInfo or FieldInfo))
-                {
-                    throw new ArgumentException("The path can only contain properties or fields", nameof(node));
-                }
-
-                Path.Add($".{node.Member.Name}");
-                return base.VisitMember(node);
-            }
-
-            protected override Expression VisitMethodCall(MethodCallExpression node)
-            {
-                if (node.Method.Name == "get_Item") // index access for IList
-                {
-                    var argument = node.Arguments.FirstOrDefault();
-                    if (argument != null)
-                    {
-                        HandleIndexes(argument);
-                    }
-                }
-
-                return base.VisitMethodCall(node);
-            }
-
-            private void HandleIndexes(Expression argument)
-            {
-                if (argument.NodeType == ExpressionType.Constant && argument.Type == typeof(int))
-                {
-                    int? value = (int)((ConstantExpression)argument).Value;
-                    Path.Add(value is 42 or -1 or null ? "[*]" : $"[{value}]");
-                }
-            }
-
-            protected override Expression VisitBinary(BinaryExpression node)
-            {
-                if (node.NodeType == ExpressionType.ArrayIndex &&
-                    node.Right.NodeType == ExpressionType.Constant)
-                {
-                    HandleIndexes(node.Right);
-                }
-
-                return base.VisitBinary(node);
-            }
         }
     }
 }

--- a/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/SnapshotExtensionTests.cs
+++ b/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/SnapshotExtensionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using FluentAssertions.Primitives;
 using Snapshooter.Tests.Data;
 using Xunit;
@@ -31,6 +32,18 @@ namespace Snapshooter.Xunit.Tests.LambdaExpressionsTests
                     .AcceptField(m => m.DateOfBirth)
                     .IgnoreFields(m => m.Children['*'].Name)
                 );
+        }
+
+        [Fact]
+        public void MatchSnapshot_FieldWithRandomInput_IgnoreField()
+        {
+            // arrange
+            TestPerson testPerson = TestDataBuilder.TestPersonMarkWalton().Build();
+            testPerson.Age = new Random().Next(0, 100);
+
+            // act & assert
+            Snapshot.Match(testPerson, options => options
+                .IgnoreField(m => m.Age));
         }
     }
 }

--- a/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/SnapshotExtensionTests.cs
+++ b/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/SnapshotExtensionTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using FluentAssertions.Primitives;
+using Snapshooter.Tests.Data;
+using Xunit;
+
+// Extension of Fluent assertion to not loose type information of asserted object
+namespace FluentAssertions.Primitives
+{
+    public class TypedAssertions<T> : ObjectAssertions<T, TypedAssertions<T>>
+    {
+        public TypedAssertions(T value) : base(value)
+        {
+        }
+    }
+
+    public static class Extensions
+    {
+        public static TypedAssertions<TSubject> Should<TSubject>(this TSubject actualValue)
+        {
+            return new TypedAssertions<TSubject>(actualValue);
+        }
+    }
+}
+
+namespace Snapshooter.Xunit.Tests.LambdaExpressionsTests
+{
+    public class SnapshotExtensionTests
+    {
+        [Fact]
+        public void MatchSnapshot_ShouldFluentAssertions_RemovesSubject()
+        {
+            // arrange
+            TestPerson testPerson = TestDataBuilder.TestPersonMarkWalton().Build();
+
+            // act & assert
+            testPerson.Should().MatchSnapshot(o => o
+                .AcceptField(m => m.Firstname)
+                .AcceptField(m => m.DateOfBirth)
+                .IgnoreFields(m => m.Children['*'].Name));
+        }
+    }
+
+    public static class Extensions
+    {
+        public static void MatchSnapshot<TSubject>(
+            this TypedAssertions<TSubject> currentResult,
+            Func<MatchOptions<TSubject>, MatchOptions<TSubject>>? matchOptions = null)
+        {
+            var cleanedObject = currentResult.RemoveUnwantedWrappers();
+
+            Func<MatchOptions, MatchOptions>? chainedMatchOptions =
+                matchOptions != null ? m => matchOptions(new MatchOptions<TSubject>(m)) : null;
+
+            Snapshot.Match(
+                cleanedObject,
+                chainedMatchOptions);
+        }
+    }
+
+    /// <summary>
+    /// MatchOption which also knows the type of the object we assert against.
+    /// </summary>
+    public class MatchOptions<TModel> : MatchOptions
+    {
+        public MatchOptions(MatchOptions predecessor)
+        {
+            _matchOperators = predecessor.MatchOperators.ToList();
+        }
+
+        public MatchOptions<TModel> AcceptField<TU>(Expression<Func<TModel, TU>> fieldPath)
+        {
+            var path = LambdaPath<TModel>.Get(fieldPath);
+            Accept<TU>(path);
+
+            return this;
+        }
+
+        public MatchOptions<TModel> IgnoreFields<TU>(Expression<Func<TModel, TU>> fieldPaths)
+        {
+            var path = LambdaPath<TModel>.Get(fieldPaths);
+            IgnoreFields<TU>(path);
+
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Converts a Lambda Expression into a JsonPath
+    /// </summary>
+    /// <typeparam name="TSource"></typeparam>
+    public static class LambdaPath<TSource>
+    {
+        public static string Get<TResult>(Expression<Func<TSource, TResult>> expression)
+        {
+            var visitor = new PathPrintVisitor();
+            visitor.Visit(expression.Body);
+            visitor.Path.Reverse();
+            return string.Join("", visitor.Path)
+                .Substring(1);
+        }
+
+        private class PathPrintVisitor : ExpressionVisitor
+        {
+            internal readonly List<string> Path = new();
+
+            protected override Expression VisitMember(MemberExpression node)
+            {
+                if (!(node.Member is PropertyInfo or FieldInfo))
+                {
+                    throw new ArgumentException("The path can only contain properties or fields", nameof(node));
+                }
+
+                Path.Add($".{node.Member.Name}");
+                return base.VisitMember(node);
+            }
+
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                if (node.Method.Name == "get_Item") // index access for IList
+                {
+                    var argument = node.Arguments.FirstOrDefault();
+                    if (argument != null)
+                    {
+                        HandleIndexes(argument);
+                    }
+                }
+
+                return base.VisitMethodCall(node);
+            }
+
+            private void HandleIndexes(Expression argument)
+            {
+                if (argument.NodeType == ExpressionType.Constant && argument.Type == typeof(int))
+                {
+                    int? value = (int)((ConstantExpression)argument).Value;
+                    Path.Add(value is 42 or -1 or null ? "[*]" : $"[{value}]");
+                }
+            }
+
+            protected override Expression VisitBinary(BinaryExpression node)
+            {
+                if (node.NodeType == ExpressionType.ArrayIndex &&
+                    node.Right.NodeType == ExpressionType.Constant)
+                {
+                    HandleIndexes(node.Right);
+                }
+
+                return base.VisitBinary(node);
+            }
+        }
+    }
+}

--- a/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/SnapshotExtensionTests.cs
+++ b/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/SnapshotExtensionTests.cs
@@ -18,5 +18,19 @@ namespace Snapshooter.Xunit.Tests.LambdaExpressionsTests
                 .AcceptField(m => m.DateOfBirth)
                 .IgnoreFields(m => m.Children['*'].Name));
         }
+
+        [Fact]
+        public void MatchSnapshot_SnapshotMatchAssertions_RemovesSubject()
+        {
+            // arrange
+            TestPerson testPerson = TestDataBuilder.TestPersonMarkWalton().Build();
+
+            // act & assert
+            Snapshot.Match(testPerson, options => options
+                    .AcceptField(m => m.Firstname)
+                    .AcceptField(m => m.DateOfBirth)
+                    .IgnoreFields(m => m.Children['*'].Name)
+                );
+        }
     }
 }

--- a/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_FieldWithRandomInput_IgnoreField.snap
+++ b/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_FieldWithRandomInput_IgnoreField.snap
@@ -1,0 +1,56 @@
+﻿{
+  "Id": "c78c698f-9ee5-4b4b-9a0e-ef729b1f8ec8",
+  "Firstname": "Mark",
+  "Lastname": "Walton",
+  "CreationDate": "2018-06-06T00:00:00",
+  "DateOfBirth": "2000-06-25T00:00:00",
+  "Age": 84,
+  "Size": 182.5214,
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  },
+  "Children": [
+    {
+      "Name": "James",
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": null,
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": "Hanna",
+      "DateOfBirth": "2012-03-20T00:00:00"
+    }
+  ],
+  "Relatives": [
+    {
+      "Id": "fcf04ca6-d8f2-4214-a3ff-d0ded5bad4de",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Size": 165.23,
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      },
+      "Children": [],
+      "Relatives": null
+    }
+  ]
+}

--- a/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_ShouldFluentAssertions_RemovesSubject.snap
+++ b/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_ShouldFluentAssertions_RemovesSubject.snap
@@ -1,0 +1,58 @@
+
+
+{
+  "Id": "c78c698f-9ee5-4b4b-9a0e-ef729b1f8ec8",
+  "Firstname": "AcceptAny<String>",
+  "Lastname": "Walton",
+  "CreationDate": "2018-06-06T00:00:00",
+  "DateOfBirth": "AcceptAny<DateTime?>",
+  "Age": 30,
+  "Size": 182.5214,
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  },
+  "Children": [
+    {
+      "Name": "James123",
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": null,
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": "Hanna",
+      "DateOfBirth": "2012-03-20T00:00:00"
+    }
+  ],
+  "Relatives": [
+    {
+      "Id": "fcf04ca6-d8f2-4214-a3ff-d0ded5bad4de",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Size": 165.23,
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      },
+      "Children": [],
+      "Relatives": null
+    }
+  ]
+}

--- a/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_SnapshotMatchAssertions_RemovesSubject.snap
+++ b/src/Snapshooter.Xunit.Tests/LambdaExpressionsTests/__snapshots__/SnapshotExtensionTests.MatchSnapshot_SnapshotMatchAssertions_RemovesSubject.snap
@@ -1,0 +1,56 @@
+﻿{
+  "Id": "c78c698f-9ee5-4b4b-9a0e-ef729b1f8ec8",
+  "Firstname": "AcceptAny<String>",
+  "Lastname": "Walton",
+  "CreationDate": "2018-06-06T00:00:00",
+  "DateOfBirth": "AcceptAny<DateTime?>",
+  "Age": 30,
+  "Size": 182.5214,
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  },
+  "Children": [
+    {
+      "Name": "James",
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": null,
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": "Hanna",
+      "DateOfBirth": "2012-03-20T00:00:00"
+    }
+  ],
+  "Relatives": [
+    {
+      "Id": "fcf04ca6-d8f2-4214-a3ff-d0ded5bad4de",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Size": 165.23,
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      },
+      "Children": [],
+      "Relatives": null
+    }
+  ]
+}

--- a/src/Snapshooter.Xunit.Tests/Snapshooter.Xunit.Tests.csproj
+++ b/src/Snapshooter.Xunit.Tests/Snapshooter.Xunit.Tests.csproj
@@ -36,6 +36,7 @@
     <Folder Include="AcceptMatchOption\AcceptString\__snapshots__\__mismatch__\" />
     <Folder Include="Asynchronous\__snapshots__\" />
     <Folder Include="Asynchronous\__snapshots__\__mismatch__\" />
+    <Folder Include="LambdaExpressionsTests\__snapshots__\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Snapshooter.Xunit/Snapshot.cs
+++ b/src/Snapshooter.Xunit/Snapshot.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading;
 using Snapshooter.Core;
 using Snapshooter.Core.Serialization;
-using Snapshooter.MatchOptionsOfModel.cs;
 
 namespace Snapshooter.Xunit
 {

--- a/src/Snapshooter.Xunit/Snapshot.cs
+++ b/src/Snapshooter.Xunit/Snapshot.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Threading;
 using Snapshooter.Core;
 using Snapshooter.Core.Serialization;
+using Snapshooter.MatchOptionsOfModel.cs;
 
 namespace Snapshooter.Xunit
 {
@@ -30,9 +31,11 @@ namespace Snapshooter.Xunit
         /// </param>
         public static void Match<T>(
             T currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions<T>, MatchOptions<T>> matchOptions = null)
         {
-            Match((object)currentResult, matchOptions);
+            Match(
+                (object)currentResult,
+                o => matchOptions == null ? o : matchOptions(new MatchOptions<T>(o)));
         }
 
         /// <summary>
@@ -58,9 +61,12 @@ namespace Snapshooter.Xunit
         public static void Match<T>(
             T currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions<T>, MatchOptions<T>> matchOptions = null)
         {
-            Match((object)currentResult, snapshotNameExtension, matchOptions);
+            Match(
+                (object)currentResult,
+                snapshotNameExtension,
+                o => matchOptions == null ? o : matchOptions(new MatchOptions<T>(o)));
         }
 
         /// <summary>
@@ -81,9 +87,12 @@ namespace Snapshooter.Xunit
         public static void Match<T>(
             T currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions<T>, MatchOptions<T>> matchOptions = null)
         {
-            Match((object)currentResult, snapshotName, matchOptions);
+            Match(
+                (object)currentResult,
+                snapshotName,
+                o => matchOptions == null ? o : matchOptions(new MatchOptions<T>(o)));
         }
 
         /// <summary>
@@ -114,9 +123,13 @@ namespace Snapshooter.Xunit
             T currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions<T>, MatchOptions<T>> matchOptions = null)
         {
-            Match((object)currentResult, snapshotName, snapshotNameExtension, matchOptions);
+            Match(
+                (object)currentResult,
+                snapshotName,
+                snapshotNameExtension,
+                o => matchOptions == null ? o : matchOptions(new MatchOptions<T>(o)));
         }
 
         /// <summary>
@@ -134,9 +147,12 @@ namespace Snapshooter.Xunit
         public static void Match<T>(
             T currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions<T>, MatchOptions<T>> matchOptions = null)
         {
-            Match((object)currentResult, snapshotFullName, matchOptions);
+            Match(
+                (object)currentResult,
+                snapshotFullName,
+                o => matchOptions == null ? o : matchOptions(new MatchOptions<T>(o)));
         }
 
         /// <summary>

--- a/src/Snapshooter.Xunit/SnapshotExtension.cs
+++ b/src/Snapshooter.Xunit/SnapshotExtension.cs
@@ -1,5 +1,5 @@
 using System;
-using FluentAssertions.Primitives;
+using FluentAssertions;
 
 namespace Snapshooter.Xunit
 {

--- a/src/Snapshooter.Xunit/SnapshotExtension.cs
+++ b/src/Snapshooter.Xunit/SnapshotExtension.cs
@@ -1,5 +1,6 @@
 using System;
-using Xunit;
+using FluentAssertions.Primitives;
+using Snapshooter.MatchOptionsOfModel.cs;
 
 namespace Snapshooter.Xunit
 {
@@ -127,6 +128,30 @@ namespace Snapshooter.Xunit
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotFullName, matchOptions);
+        }
+
+        /// <summary>
+        /// Creates a json snapshot of the given object and compares it with the
+        /// already existing snapshot of the test.
+        /// If no snapshot exists, a new snapshot will be created from the current result
+        /// and saved under a certain file path, which will shown within the test message.
+        /// </summary>
+        /// <param name="currentResult">The object to match.</param>
+        /// <param name="matchOptions">
+        /// Additional compare actions, which can be applied during the snapshot comparison
+        /// </param>
+        public static void MatchSnapshot<TSubject>(
+            this TypedAssertions<TSubject> currentResult,
+            Func<MatchOptions<TSubject>, MatchOptions<TSubject>>? matchOptions = null)
+        {
+            var cleanedObject = currentResult.RemoveUnwantedWrappers();
+
+            Func<MatchOptions, MatchOptions>? chainedMatchOptions =
+                matchOptions != null ? m => matchOptions(new MatchOptions<TSubject>(m)) : null;
+
+            Snapshot.Match(
+                cleanedObject,
+                chainedMatchOptions);
         }
     }
 }

--- a/src/Snapshooter.Xunit/SnapshotExtension.cs
+++ b/src/Snapshooter.Xunit/SnapshotExtension.cs
@@ -1,6 +1,5 @@
 using System;
 using FluentAssertions.Primitives;
-using Snapshooter.MatchOptionsOfModel.cs;
 
 namespace Snapshooter.Xunit
 {

--- a/src/Snapshooter/Exceptions/LambdaPathConversionException.cs
+++ b/src/Snapshooter/Exceptions/LambdaPathConversionException.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Snapshooter.Exceptions;
+
+/// <summary>
+/// Exception thrown if something went wrong during converting a lambda expression into a path.
+/// </summary>
+public class LambdaPathConversionException : SnapshotTestException
+{
+    /// <summary>
+    /// Initializes the <see cref="LambdaPathConversionException"/>
+    /// </summary>
+    public LambdaPathConversionException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes the <see cref="LambdaPathConversionException"/>
+    /// <param name="message">The exception message.</param>
+    /// </summary>
+    public LambdaPathConversionException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes the <see cref="LambdaPathConversionException"/>
+    /// <param name="message">The exception message.</param>
+    /// <param name="inner">The inner exception.</param>
+    /// </summary>
+    public LambdaPathConversionException(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+}

--- a/src/Snapshooter/Extensions/FluentAssertionsExtension.cs
+++ b/src/Snapshooter/Extensions/FluentAssertionsExtension.cs
@@ -1,5 +1,7 @@
+using FluentAssertions.Primitives;
+
 // Extension of Fluent assertion to not loose type information of asserted object
-namespace FluentAssertions.Primitives;
+namespace FluentAssertions;
 
 public class TypedAssertions<T> : ObjectAssertions<T, TypedAssertions<T>>
 {

--- a/src/Snapshooter/Extensions/FluentAssertionsExtension.cs
+++ b/src/Snapshooter/Extensions/FluentAssertionsExtension.cs
@@ -1,0 +1,17 @@
+// Extension of Fluent assertion to not loose type information of asserted object
+namespace FluentAssertions.Primitives;
+
+public class TypedAssertions<T> : ObjectAssertions<T, TypedAssertions<T>>
+{
+    public TypedAssertions(T value) : base(value)
+    {
+    }
+}
+
+public static class Extensions
+{
+    public static TypedAssertions<TSubject> Should<TSubject>(this TSubject actualValue)
+    {
+        return new TypedAssertions<TSubject>(actualValue);
+    }
+}

--- a/src/Snapshooter/Helpers/LambdaPath.cs
+++ b/src/Snapshooter/Helpers/LambdaPath.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Snapshooter.Exceptions;
+
+namespace Snapshooter.Helpers;
+
+/// <summary>
+/// Converts a Lambda Expression into a JsonPath
+/// </summary>
+public static class LambdaPath<TSource>
+{
+    /// <summary>
+    /// Converts the given expression into a jsonPath
+    /// </summary>
+    public static string Get<TResult>(Expression<Func<TSource, TResult>> expression)
+    {
+        var visitor = new PathPrintVisitor();
+        visitor.Visit(expression.Body);
+        visitor.Path.Reverse();
+
+        var joinedPath = string.Join("", visitor.Path);
+
+        if (string.IsNullOrWhiteSpace(joinedPath))
+        {
+            throw new LambdaPathConversionException(
+                "Given lambda expression could not be converted to path");
+        }
+
+        return joinedPath.StartsWith(".") ? joinedPath.Substring(1) : joinedPath;
+    }
+
+    private class PathPrintVisitor : ExpressionVisitor
+    {
+        internal readonly List<string> Path = new();
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            if (!(node.Member is PropertyInfo or FieldInfo))
+            {
+                throw new LambdaPathConversionException(
+                    "The path can only contain properties or fields");
+            }
+
+            Path.Add($".{node.Member.Name}");
+            return base.VisitMember(node);
+        }
+
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            if (node.Method.Name == "get_Item") // index access for IList
+            {
+                Expression argument = node.Arguments.FirstOrDefault();
+                if (argument != null)
+                {
+                    HandleIndexes(argument);
+                }
+            }
+
+            return base.VisitMethodCall(node);
+        }
+
+        private void HandleIndexes(Expression argument)
+        {
+            if (argument.NodeType == ExpressionType.Constant && argument.Type == typeof(int))
+            {
+                int? value = (int?)((ConstantExpression)argument).Value;
+                // the char '*' will be cast to the integer 42 
+                Path.Add(value is 42 or -1 or null ? "[*]" : $"[{value}]");
+            }
+        }
+
+        protected override Expression VisitBinary(BinaryExpression node)
+        {
+            if (node.NodeType == ExpressionType.ArrayIndex &&
+                node.Right.NodeType == ExpressionType.Constant)
+            {
+                HandleIndexes(node.Right);
+            }
+
+            return base.VisitBinary(node);
+        }
+    }
+}

--- a/src/Snapshooter/MatchOptions.cs
+++ b/src/Snapshooter/MatchOptions.cs
@@ -474,7 +474,7 @@ namespace Snapshooter
             return this;
         }
 
-        private MatchOptions Accept<T>(
+        protected MatchOptions Accept<T>(
             string fieldsPath,
             bool keepOriginalValue = false)
         {

--- a/src/Snapshooter/MatchOptionsOfModel.cs
+++ b/src/Snapshooter/MatchOptionsOfModel.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using Snapshooter.Helpers;
 
-namespace Snapshooter.MatchOptionsOfModel.cs;
+namespace Snapshooter;
 
 /// <summary>
 /// <see cref="MatchOptions"/> which also knows the type of the object we assert against.
@@ -25,22 +25,33 @@ public class MatchOptions<TModel> : MatchOptions
     /// compared with the original snapshot.
     /// In addition, the field will be replaced by the text 'AcceptAny{T}()'"
     /// </summary>
-    public MatchOptions<TModel> AcceptField<TU>(Expression<Func<TModel, TU>> fieldPath)
+    public MatchOptions<TModel> AcceptField<TU>(Expression<Func<TModel, TU>> field)
     {
-        var path = LambdaPath<TModel>.Get(fieldPath);
+        var path = LambdaPath<TModel>.Get(field);
         Accept<TU>(path);
 
         return this;
     }
 
+    /// <summary>
+    /// The <see cref="IgnoreField{TU}"/> option ignores the existing field given by the 
+    /// lambda expression. The field will be ignored during snapshot comparison.
+    /// </summary>
+    public MatchOptions<TModel> IgnoreField<TU>(Expression<Func<TModel, TU>> field)
+    {
+        var path = LambdaPath<TModel>.Get(field);
+        IgnoreField<TU>(path);
+
+        return this;
+    }
 
     /// <summary>
     /// The <see cref="IgnoreFields{TU}"/> option ignores the existing field(s) given by the 
     /// lambda expression. The field(s) will be ignored during snapshot comparison.
     /// </summary>
-    public MatchOptions<TModel> IgnoreFields<TU>(Expression<Func<TModel, TU>> fieldPaths)
+    public MatchOptions<TModel> IgnoreFields<TU>(Expression<Func<TModel, TU>> fields)
     {
-        var path = LambdaPath<TModel>.Get(fieldPaths);
+        var path = LambdaPath<TModel>.Get(fields);
         IgnoreFields<TU>(path);
 
         return this;

--- a/src/Snapshooter/MatchOptionsOfModel.cs/MatchOptions.cs
+++ b/src/Snapshooter/MatchOptionsOfModel.cs/MatchOptions.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Snapshooter.Helpers;
+
+namespace Snapshooter.MatchOptionsOfModel.cs;
+
+/// <summary>
+/// <see cref="MatchOptions"/> which also knows the type of the object we assert against.
+/// </summary>
+public class MatchOptions<TModel> : MatchOptions
+{
+    /// <summary>
+    /// Constructor of the <see cref="MatchOptions{TModel}"/> class to create
+    /// a new instance.
+    /// </summary>
+    public MatchOptions(MatchOptions predecessor)
+    {
+        _matchOperators = predecessor.MatchOperators.ToList();
+    }
+
+    /// <summary>
+    /// The <see cref="AcceptField{TU}"/> match option accepts a
+    /// lambda expression pointing to a field. The value of the field will NOT be 
+    /// compared with the original snapshot.
+    /// In addition, the field will be replaced by the text 'AcceptAny{T}()'"
+    /// </summary>
+    public MatchOptions<TModel> AcceptField<TU>(Expression<Func<TModel, TU>> fieldPath)
+    {
+        var path = LambdaPath<TModel>.Get(fieldPath);
+        Accept<TU>(path);
+
+        return this;
+    }
+
+
+    /// <summary>
+    /// The <see cref="IgnoreFields{TU}"/> option ignores the existing field(s) given by the 
+    /// lambda expression. The field(s) will be ignored during snapshot comparison.
+    /// </summary>
+    public MatchOptions<TModel> IgnoreFields<TU>(Expression<Func<TModel, TU>> fieldPaths)
+    {
+        var path = LambdaPath<TModel>.Get(fieldPaths);
+        IgnoreFields<TU>(path);
+
+        return this;
+    }
+}

--- a/src/Snapshooter/Snapshooter.csproj
+++ b/src/Snapshooter/Snapshooter.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
_This PR is a work in progress_

We can now accept and ignore fields in a type safe way.

Open point: We have 3 syntax how we can assert a snapshot. 
  - With fluent assertions: `person.Should().MatchSnapshot()`
  - With the static snapshot class `Snapshot.Match(person)`
  - With the MatchSnapshot extension: `person.MatchSnapshot()`
  
Due to limitations with generics we cannot support lambda expressions for both the MatchSnapshot and the fluent assertion way. The current state of the pr only supports lambda expressions for fluent assertions and for static snapshot matches. 
We could support lambda expressions for all 3 ways if we would perform a  rename. E.g. ` person.Should().MatchSnapshot()` would need to become `person.Shoult().Match()`. Not sure if this is an acceptable solution or if we should just not support lambda expressions for the MatchSnapshot extension syntax. 
