### PR TITLE
Implemented Include Field Match Option.

### DIFF
--- a/src/Snapshooter/Core/MatchOperators/ExcludeMatchOperator.cs
+++ b/src/Snapshooter/Core/MatchOperators/ExcludeMatchOperator.cs
@@ -32,7 +32,11 @@ public class ExcludeMatchOperator : FieldMatchOperator
 
     private JToken FormatField(JToken field)
     {
-        if (field.Parent is { } parent)
+        if (field.Parent is JArray array)
+        {
+            array.Remove(field);
+        }
+        else if (field.Parent is { } parent)
         {
             parent.Remove();
         }

--- a/src/Snapshooter/Core/MatchOperators/IncludeMatchOperator.cs
+++ b/src/Snapshooter/Core/MatchOperators/IncludeMatchOperator.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Snapshooter.Core;
+
+public class IncludeMatchOperator : FieldMatchOperator
+{
+    private readonly List<string> _fieldsPaths;
+
+    public IncludeMatchOperator()
+    {
+        _fieldsPaths = new List<string>();
+    }
+
+    public override bool HasFormatAction() => true;
+
+    public void AddFieldPath(string fieldPath)
+    {
+        if(!_fieldsPaths.Contains(fieldPath))
+        {
+            _fieldsPaths.Add(fieldPath);
+        }
+    }
+
+    public override void FormatFields(JToken snapshotData)
+    {
+        FieldOption fieldOption = new FieldOption(snapshotData);
+
+        List<JToken> includedFields = new List<JToken>();
+
+        foreach(string fieldPath in _fieldsPaths)
+        {
+            List<JToken> fieldsToInclude = fieldOption
+                .FindFieldTokens(fieldPath)
+                .ToList();
+
+            includedFields.AddRange(fieldsToInclude);
+        }
+            
+        FilterIncludedFieldsOnly(snapshotData, includedFields);
+    }
+
+    public override FieldOption ExecuteMatch(
+        JToken snapshotData,
+        JToken expectedSnapshotData)
+    {
+        return new FieldOption(snapshotData);
+    }
+
+    private static void FilterIncludedFieldsOnly(
+        JToken snapshotField,
+        List<JToken> includedFields)
+    {
+        foreach (JToken child in snapshotField.Children().ToList())
+        {
+            if (child.HasValues)
+            {
+                if (!includedFields.Any(field =>
+                    child.Path.StartsWith(field.Path) ||
+                    field.Path.StartsWith(child.Path)))
+                {
+                    RemoveField(child);
+
+                    continue;
+                }
+
+                FilterIncludedFieldsOnly(child, includedFields);
+            }
+        }
+    }
+
+    private static void RemoveField(JToken child)
+    {
+        if (child is JProperty property)
+        {
+            property.Remove();
+        }
+        else if (child.Parent is JArray array)
+        {
+            array.Remove(child);
+        }
+        else if (child is JValue value)
+        {
+            value.Parent?.Remove();
+        }
+    }
+}
+

--- a/src/Snapshooter/MatchOptions.cs
+++ b/src/Snapshooter/MatchOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Snapshooter.Core;
 using Snapshooter.Exceptions;
 
@@ -474,6 +475,30 @@ namespace Snapshooter
             return this;
         }
 
+        /// <summary>
+        /// The <see cref="IncludeField(string)"/> option includes only the field(s) in a snapshot,
+        /// which have been defined by the fieldPath.
+        /// The field(s) to include is given by the json path <paramref name="fieldPath"/>.
+        /// Only these fields will appear in the snapshot.
+        /// </summary>
+        /// <param name="fieldPath">The json path to the field(s) to include.</param>
+        public MatchOptions IncludeField(string fieldPath)
+        {
+            FieldMatchOperator fieldMatchOperator =
+                _matchOperators.SingleOrDefault(op => op is IncludeMatchOperator);
+
+            if (fieldMatchOperator == null)
+            {
+                fieldMatchOperator = new IncludeMatchOperator();
+                _matchOperators.Add(fieldMatchOperator);
+            }
+
+            var includeMatchOperator = (IncludeMatchOperator)fieldMatchOperator;
+
+            includeMatchOperator.AddFieldPath(fieldPath);
+
+            return this;
+        }
 
         private MatchOptions AddIgnoreMatchOperator<T>(string fieldsPath)
         {

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/ExcludeField/ExcludeFieldTests.cs
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/ExcludeField/ExcludeFieldTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net;
 using FluentAssertions;
 using Snapshooter.Tests.Data;
 using Snapshooter.Xunit.Tests.Helpers;
@@ -158,5 +159,40 @@ public class ExcludeFieldsTests
         // assert
         act.Should().Throw<EqualException>()
             .Which.Message.Should().Contain("CountryCode");
+    }
+
+    [Fact]
+    public void ExcludeField_DuplicateExcludeFieldsSnapshot_SuccessfullyCompared()
+    {
+        // arrange
+        TestPerson testPerson = TestDataBuilder
+            .TestPersonMarkWalton()
+            .Build();
+
+        // act & assert
+        Snapshot.Match(testPerson, options => options
+            .ExcludeField("Firstname")
+            .ExcludeField("DateOfBirth")
+            .ExcludeField("Size")
+            .ExcludeField("Address.Country.CountryCode")
+            .ExcludeField("Children")
+            .ExcludeField("Relatives[*].Relatives")
+            .ExcludeField("Relatives[*].Address")
+            .ExcludeField("Relatives[*].Address")
+            .ExcludeField("**.Size")
+            .ExcludeField("**.CountryCode"));
+    }
+
+    [Fact]
+    public void ExcludeField_ExcludeArrayFieldSnapshot_SuccessfullyCompared()
+    {
+        // arrange
+        TestPerson testPerson = TestDataBuilder
+            .TestPersonMarkWalton()
+            .Build();
+
+        // act & assert
+        Snapshot.Match(testPerson, options => options
+            .ExcludeField("Children[0]"));
     }
 }

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/ExcludeField/__snapshots__/ExcludeFieldsTests.ExcludeField_DuplicateExcludeFieldsSnapshot_SuccessfullyCompared.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/ExcludeField/__snapshots__/ExcludeFieldsTests.ExcludeField_DuplicateExcludeFieldsSnapshot_SuccessfullyCompared.snap
@@ -1,0 +1,26 @@
+﻿{
+  "Id": "c78c698f-9ee5-4b4b-9a0e-ef729b1f8ec8",
+  "Lastname": "Walton",
+  "CreationDate": "2018-06-06T00:00:00",
+  "Age": 30,
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland"
+    }
+  },
+  "Relatives": [
+    {
+      "Id": "fcf04ca6-d8f2-4214-a3ff-d0ded5bad4de",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Children": []
+    }
+  ]
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/ExcludeField/__snapshots__/ExcludeFieldsTests.ExcludeField_ExcludeArrayFieldSnapshot_SuccessfullyCompared.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/ExcludeField/__snapshots__/ExcludeFieldsTests.ExcludeField_ExcludeArrayFieldSnapshot_SuccessfullyCompared.snap
@@ -1,0 +1,52 @@
+﻿{
+  "Id": "c78c698f-9ee5-4b4b-9a0e-ef729b1f8ec8",
+  "Firstname": "Mark",
+  "Lastname": "Walton",
+  "CreationDate": "2018-06-06T00:00:00",
+  "DateOfBirth": "2000-06-25T00:00:00",
+  "Age": 30,
+  "Size": 182.5214,
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  },
+  "Children": [
+    {
+      "Name": null,
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": "Hanna",
+      "DateOfBirth": "2012-03-20T00:00:00"
+    }
+  ],
+  "Relatives": [
+    {
+      "Id": "fcf04ca6-d8f2-4214-a3ff-d0ded5bad4de",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Size": 165.23,
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      },
+      "Children": [],
+      "Relatives": null
+    }
+  ]
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/IncludeFieldTests.cs
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/IncludeFieldTests.cs
@@ -1,0 +1,122 @@
+using Snapshooter.Tests.Data;
+using Xunit;
+
+namespace Snapshooter.Xunit.Tests.MatchOptions.IncludeField;
+
+public class IncludeFieldTests
+{
+    [Fact]
+    public void IncludeField_StringScalarField_IncludedOnlyField()
+    {
+        // arrange
+        TestPerson testPerson = TestDataBuilder
+            .TestPersonMarkWalton()
+            .Build();
+
+        // act & assert
+        Snapshot.Match(testPerson, options => options
+            .IncludeField("Firstname"));
+    }
+
+    [Fact]
+    public void IncludeField_StringScalarFields_IncludedOnlyFields()
+    {
+        // arrange
+        TestPerson testPerson = TestDataBuilder
+            .TestPersonMarkWalton()
+            .Build();
+
+        // act & assert
+        Snapshot.Match(testPerson, options => options
+            .IncludeField("Firstname")
+            .IncludeField("Age")
+            .IncludeField("CreationDate"));
+    }
+
+    [Fact]
+    public void IncludeField_StringDuplicatedScalarFields_IncludedOnlyFields()
+    {
+        // arrange
+        TestPerson testPerson = TestDataBuilder
+            .TestPersonMarkWalton()
+            .Build();
+
+        // act & assert
+        Snapshot.Match(testPerson, options => options
+            .IncludeField("Age")
+            .IncludeField("Lastname")
+            .IncludeField("Age")
+            .IncludeField("**.Lastname"));
+    }
+    
+    [Fact]
+    public void IncludeField_ComplexObjectField_IncludedOnlyField()
+    {
+        // arrange
+        TestPerson testPerson = TestDataBuilder
+            .TestPersonMarkWalton()
+            .Build();
+
+        // act & assert
+        Snapshot.Match(testPerson, options => options
+            .IncludeField("Address"));
+    }
+
+    [Fact]
+    public void IncludeField_IncludeTwiceInPath_RightFieldIncluded()
+    {
+        // arrange
+        TestPerson testPerson = TestDataBuilder
+            .TestPersonMarkWalton()
+            .Build();
+
+        // act & assert
+        Snapshot.Match(testPerson, options => options
+            .IncludeField("Address")
+            .IncludeField("Address.Country"));
+    }
+
+    [Fact]
+    public void IncludeField_IncludeTwoDifferentFields_RightFieldIncluded()
+    {
+        // arrange
+        TestPerson testPerson = TestDataBuilder
+            .TestPersonMarkWalton()
+            .Build();
+
+        // act & assert
+        Snapshot.Match(testPerson, options => options
+            .IncludeField("Children")
+            .IncludeField("Relatives"));
+    }
+
+    [Fact]
+    public void IncludeField_IncludeFieldsByName_IncludedOnlyFields()
+    {
+        // arrange
+        TestPerson testPerson = TestDataBuilder
+            .TestPersonMarkWalton()
+            .Build();
+
+        // act & assert
+        Snapshot.Match(testPerson, options => options
+            .IncludeField("**.Address")
+            .IncludeField("**.Name")
+            .IncludeField("**.Country")
+            .IncludeField("**.Lastname"));
+    }
+
+    [Fact]
+    public void IncludeField_IncludeArrayFields_IncludedOnlyFields()
+    {
+        // arrange
+        TestPerson testPerson = TestDataBuilder
+            .TestPersonMarkWalton()
+            .Build();
+
+        // act & assert
+        Snapshot.Match(testPerson, options => options
+            .IncludeField("Children[2]")
+            .IncludeField("Relatives[0]"));
+    }
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_ComplexObjectField_IncludedOnlyField.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_ComplexObjectField_IncludedOnlyField.snap
@@ -1,0 +1,12 @@
+﻿{
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  }
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_IncludeArrayFields_IncludedOnlyFields.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_IncludeArrayFields_IncludedOnlyFields.snap
@@ -1,0 +1,31 @@
+﻿{
+  "Children": [
+    {
+      "Name": "Hanna",
+      "DateOfBirth": "2012-03-20T00:00:00"
+    }
+  ],
+  "Relatives": [
+    {
+      "Id": "fcf04ca6-d8f2-4214-a3ff-d0ded5bad4de",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Size": 165.23,
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      },
+      "Children": [],
+      "Relatives": null
+    }
+  ]
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_IncludeFieldsByName_IncludedOnlyFields.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_IncludeFieldsByName_IncludedOnlyFields.snap
@@ -1,0 +1,39 @@
+﻿{
+  "Lastname": "Walton",
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  },
+  "Children": [
+    {
+      "Name": "James"
+    },
+    {
+      "Name": null
+    },
+    {
+      "Name": "Hanna"
+    }
+  ],
+  "Relatives": [
+    {
+      "Lastname": "Schneider",
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      }
+    }
+  ]
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_IncludeTwiceInPath_RightFieldIncluded.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_IncludeTwiceInPath_RightFieldIncluded.snap
@@ -1,0 +1,12 @@
+﻿{
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  }
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_IncludeTwoDifferentFields_RightFieldIncluded.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_IncludeTwoDifferentFields_RightFieldIncluded.snap
@@ -1,0 +1,39 @@
+﻿{
+  "Children": [
+    {
+      "Name": "James",
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": null,
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": "Hanna",
+      "DateOfBirth": "2012-03-20T00:00:00"
+    }
+  ],
+  "Relatives": [
+    {
+      "Id": "fcf04ca6-d8f2-4214-a3ff-d0ded5bad4de",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Size": 165.23,
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      },
+      "Children": [],
+      "Relatives": null
+    }
+  ]
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_StringDuplicatedScalarFields_IncludedOnlyFields.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_StringDuplicatedScalarFields_IncludedOnlyFields.snap
@@ -1,0 +1,9 @@
+﻿{
+  "Lastname": "Walton",
+  "Age": 30,
+  "Relatives": [
+    {
+      "Lastname": "Schneider"
+    }
+  ]
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_StringScalarField_IncludedOnlyField.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_StringScalarField_IncludedOnlyField.snap
@@ -1,0 +1,3 @@
+﻿{
+  "Firstname": "Mark"
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_StringScalarFields_IncludedOnlyFields.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/IncludeField/__snapshots__/IncludeFieldTests.IncludeField_StringScalarFields_IncludedOnlyFields.snap
@@ -1,0 +1,5 @@
+﻿{
+  "Firstname": "Mark",
+  "CreationDate": "2018-06-06T00:00:00",
+  "Age": 30
+}

--- a/test/Snapshooter.Xunit.Tests/Snapshooter.Xunit.Tests.csproj
+++ b/test/Snapshooter.Xunit.Tests/Snapshooter.Xunit.Tests.csproj
@@ -37,7 +37,10 @@
     <Folder Include="AcceptMatchOption\AcceptString\__snapshots__\__mismatch__\" />
     <Folder Include="Asynchronous\__snapshots__\" />
     <Folder Include="Asynchronous\__snapshots__\__mismatch__\" />
+    <Folder Include="MatchOptions\ExcludeField\__snapshots__\__mismatch__\" />
     <Folder Include="MatchOptions\HashField\__snapshots__\__mismatch__\" />
+    <Folder Include="MatchOptions\IncludeField\__snapshots__\" />
+    <Folder Include="MatchOptions\IncludeField\__snapshots__\__mismatch__\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Implemented the include match option feature. With the include field match option we can include only single fields of the snapshot. Therefore only the fields appear in the snapshot, which have been included with this option.
