### PR TITLE
Bugfix for multiple field options within one Assert Match Option.

### DIFF
--- a/src/Snapshooter/Core/JsonSnapshotComparer.cs
+++ b/src/Snapshooter/Core/JsonSnapshotComparer.cs
@@ -78,7 +78,7 @@ namespace Snapshooter.Core
                 {
                     RemoveFieldFromSnapshot(fieldOption, actualSnapshot);
                     RemoveFieldFromSnapshot(fieldOption, expectedSnapshot);
-                }                
+                }
             }
             catch (SnapshotFieldException)
             {

--- a/src/Snapshooter/Core/JsonSnapshotComparer.cs
+++ b/src/Snapshooter/Core/JsonSnapshotComparer.cs
@@ -57,7 +57,7 @@ namespace Snapshooter.Core
             _snapshotAssert.Assert(expectedSnapshotToCompare, actualSnapshotToCompare);
         }
 
-        private void ExecuteFieldMatchActions(
+        private static void ExecuteFieldMatchActions(
             JToken actualSnapshot,
             JToken expectedSnapshot,
             MatchOptions matchOptions)
@@ -105,22 +105,27 @@ namespace Snapshooter.Core
                     $"match options are not allowed.");
             }
 
-            foreach (var fieldPath in fieldOption.FieldPaths ?? new string[] { })
+            foreach (var fieldPath in fieldOption.FieldPaths ?? Array.Empty<string>())
             {
                 IEnumerable<JToken> actualTokens = snapshot.SelectTokens(fieldPath, false);
 
-                if (actualTokens is { })
+                RemoveFields(actualTokens);
+            }
+        }
+
+        private static void RemoveFields(IEnumerable<JToken> actualTokens)
+        {
+            if (actualTokens is { })
+            {
+                foreach (JToken actual in actualTokens.ToList())
                 {
-                    foreach (JToken actual in actualTokens.ToList())
+                    if (actual.Parent is JArray array)
                     {
-                        if (actual.Parent is JArray array)
-                        {
-                            array.Remove(actual);
-                        }
-                        else
-                        {
-                            actual.Parent?.Remove();
-                        }
+                        array.Remove(actual);
+                    }
+                    else
+                    {
+                        actual.Parent?.Remove();
                     }
                 }
             }

--- a/src/Snapshooter/Core/JsonSnapshotComparer.cs
+++ b/src/Snapshooter/Core/JsonSnapshotComparer.cs
@@ -64,14 +64,21 @@ namespace Snapshooter.Core
         {
             try
             {
+                List<FieldOption> fieldOptions = new List<FieldOption>();
+
                 foreach (FieldMatchOperator matchOperator in matchOptions.MatchOperators)
                 {
                     FieldOption fieldOption = matchOperator
                         .ExecuteMatch(actualSnapshot, expectedSnapshot);
 
+                    fieldOptions.Add(fieldOption);
+                }
+
+                foreach (FieldOption fieldOption in fieldOptions)
+                {
                     RemoveFieldFromSnapshot(fieldOption, actualSnapshot);
                     RemoveFieldFromSnapshot(fieldOption, expectedSnapshot);
-                }
+                }                
             }
             catch (SnapshotFieldException)
             {

--- a/src/Snapshooter/Core/MatchOperators/AcceptMatchOperator.cs
+++ b/src/Snapshooter/Core/MatchOperators/AcceptMatchOperator.cs
@@ -48,7 +48,7 @@ namespace Snapshooter.Core
             return fieldOption;
         }
 
-        private JToken FormatField(JToken field)
+        private void FormatField(JToken field)
         {
             string originalValue = string.Empty;
             if (_keepOriginalValue)
@@ -70,8 +70,6 @@ namespace Snapshooter.Core
             string typeAlias = typeof(T).GetAliasName();
 
             field.Replace(new JValue($"AcceptAny<{typeAlias}>{originalValue}"));
-
-            return field;
         }
 
         private void VerifyFieldType(string path, object field)

--- a/src/Snapshooter/Core/MatchOperators/AcceptMatchOperator.cs
+++ b/src/Snapshooter/Core/MatchOperators/AcceptMatchOperator.cs
@@ -65,7 +65,7 @@ namespace Snapshooter.Core
                 originalValue = $"(original: '{fieldValue}')";
             }
 
-            _fields.Add(field.Path, FieldOption.ConvertToType<object>(field));
+            _fields.Add(field.Path, field.ConvertToType<object>());
 
             string typeAlias = typeof(T).GetAliasName();
 

--- a/src/Snapshooter/Extensions/JTokenExtensions.cs
+++ b/src/Snapshooter/Extensions/JTokenExtensions.cs
@@ -25,5 +25,23 @@ namespace Snapshooter.Extensions
                 })
                 .Trim('\"');
         }
+
+        /// <summary>
+        /// Converts a JToken to a specified type.
+        /// </summary>
+        /// <typeparam name="T">The type to convert to.</typeparam>
+        /// <param name="field">The JToken field to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static T ConvertToType<T>(this JToken field)
+        {
+            if (typeof(T) == typeof(int))
+            {
+                // This is a workaround, because the json method ToObject<> rounds
+                // decimal values to integer values, which is wrong.
+                return JsonConvert.DeserializeObject<T>(field.Value<string>());
+            }
+
+            return field.ToObject<T>();
+        }
     }
 }

--- a/src/Snapshooter/FieldOption.cs
+++ b/src/Snapshooter/FieldOption.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Snapshooter.Exceptions;
 using Snapshooter.Extensions;
@@ -15,6 +14,7 @@ namespace Snapshooter
     public class FieldOption
     {
         private JToken _snapshotData;
+        private List<string> _fieldPaths;
 
         /// <summary>
         /// Constructor of the class <see cref="FieldOption"/>
@@ -24,12 +24,13 @@ namespace Snapshooter
         public FieldOption(JToken snapshotData)
         {
             _snapshotData = snapshotData;
+            _fieldPaths = new List<string>();
         }
 
         /// <summary>
         /// The path of the field, which was requested.
         /// </summary>
-        public string[] FieldPaths { get; private set; }
+        public string[] FieldPaths => _fieldPaths.ToArray();
 
         /// <summary>
         /// Finds all jtokens by the given field path. if the field path
@@ -94,7 +95,7 @@ namespace Snapshooter
                         $"Please use the FieldOption for fields array (Fields).");
                 }
 
-                T fieldValue = ConvertToType<T>(fields.Single());
+                T fieldValue = fields.Single().ConvertToType<T>();
 
                 return fieldValue;
             }
@@ -118,7 +119,7 @@ namespace Snapshooter
                 IEnumerable<JToken> fields = GetTokensByPath(fieldPath);
 
                 T[] fieldValues = fields
-                    .Select(f => ConvertToType<T>(f))
+                    .Select(field => field.ConvertToType<T>())
                     .ToArray();
 
                 return fieldValues;
@@ -144,7 +145,7 @@ namespace Snapshooter
                     GetPropertiesByName(name);
 
                 T[] fieldValues = properties
-                    .Select(jprop => ConvertToType<T>(jprop.Value))
+                    .Select(jprop => jprop.Value.ConvertToType<T>())
                     .ToArray();
                 
                 return fieldValues;
@@ -178,16 +179,15 @@ namespace Snapshooter
                 .Where(jprop => jprop.Name == name)
                 .ToArray();
 
-            FieldPaths = properties
-                .Select(jprop => jprop.Path)
-                .ToArray();
+            _fieldPaths.AddRange(
+                properties.Select(jprop => jprop.Path)) ;
 
             return properties;
         }
 
         private JToken[] GetTokensByPath(string fieldPath)
         {
-            FieldPaths = new[] { fieldPath };
+            _fieldPaths.Add(fieldPath);
 
             if (_snapshotData is JValue)
             {
@@ -206,18 +206,6 @@ namespace Snapshooter
             }
 
             return jTokens.ToArray();
-        }
-
-        public static T ConvertToType<T>(JToken field)
-        {
-            if (typeof(T) == typeof(int))
-            {
-                // This is a workaround, because the json method ToObject<> rounds
-                // decimal values to integer values, which is wrong.
-                return JsonConvert.DeserializeObject<T>(field.Value<string>());
-            }
-
-            return field.ToObject<T>();
-        }
+        }        
     }
 }

--- a/src/Snapshooter/FieldOption.cs
+++ b/src/Snapshooter/FieldOption.cs
@@ -13,8 +13,8 @@ namespace Snapshooter
     /// </summary>
     public class FieldOption
     {
-        private JToken _snapshotData;
-        private List<string> _fieldPaths;
+        private readonly JToken _snapshotData;
+        private readonly List<string> _fieldPaths;
 
         /// <summary>
         /// Constructor of the class <see cref="FieldOption"/>

--- a/test/Snapshooter.Xunit.Tests/Asynchronous/SnapshotTests.Asynchronous.cs
+++ b/test/Snapshooter.Xunit.Tests/Asynchronous/SnapshotTests.Asynchronous.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Snapshooter.Exceptions;
 using Snapshooter.Tests.Data;
@@ -117,13 +117,13 @@ namespace Snapshooter.Xunit.Tests
         public async Task Match_FactMatchSnapshotInAsncMethodWithImplcName_SuccessfulMatch()
         {
             // arrange
+            Snapshot.FullName();
+
             await Task.Delay(1);
 
             TestPerson testPerson = TestDataBuilder.TestPersonSandraSchneider().Build();
 
-            await Task.Delay(1);
-
-            Snapshot.FullName();
+            await Task.Delay(1);            
 
             // act
             await AsyncMatchWithImplicitFullName(testPerson);

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/AssertField/__snapshots__/AssertFieldTests.Match_AssertMultipleTwoFieldCompares_Success.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/AssertField/__snapshots__/AssertFieldTests.Match_AssertMultipleTwoFieldCompares_Success.snap
@@ -1,0 +1,91 @@
+﻿{
+  "result": {
+    "data": {
+      "deleteDocument": {
+        "success": true,
+        "errors": null
+      }
+    }
+  },
+  "docInstances": [
+    {
+      "Id": "f80c97a9-9b91-44d0-8f79-7deeca2db556",
+      "DocumentId": "49333741-ef79-4e5a-97bc-bf2cdd3f1efd",
+      "RefId": "7ed772a2-2c33-4720-986d-8a9655b33d15",
+      "Name": "Default test document small",
+      "Tenant": "FCD",
+      "IsDeleted": true,
+      "Created": "2019-05-28T08:20:37Z",
+      "Modified": "2019-05-28T09:20:37Z",
+      "CreatedBy": "cfc67d0b-9c3c-4e4d-af2e-57fd12efc78f",
+      "ModifiedBy": "ee0a3db2-3f9e-4ce2-8f3e-f0869f366983",
+      "Metadata": [
+        {
+          "Name": "Language",
+          "Value": "En"
+        },
+        {
+          "Name": "OfferType",
+          "Value": "TestOffer"
+        },
+        {
+          "Name": "ContractId",
+          "Value": "aa5756be-4f3c-4962-8ce7-d110f94a8627"
+        },
+        {
+          "Name": "Pages",
+          "Value": 2
+        },
+        {
+          "Name": "IsSent",
+          "Value": true
+        },
+        {
+          "Name": "LetterDate",
+          "Value": "2019-05-28T10:20:37Z"
+        }
+      ],
+      "MetadataAddition": []
+    }
+  ],
+  "changeSets": [
+    {
+      "Id": "b79eb661-10ec-4adf-b3e1-f25b08bb07a2",
+      "DocumentId": null,
+      "DocumentInstanceId": "f80c97a9-9b91-44d0-8f79-7deeca2db556",
+      "UserId": "78125579-a2b1-4463-9188-23208afcd1dd",
+      "Tenant": "FCD",
+      "ChangeDate": "2022-11-18T15:21:31.967Z",
+      "Changes": [
+        {
+          "Type": "Document",
+          "Action": "Deleted",
+          "Name": null,
+          "OldValue": null,
+          "NewValue": null
+        }
+      ],
+      "Infos": {}
+    }
+  ],
+  "audits": [
+    {
+      "Id": "e1dbc5fb-68c4-4c77-a48a-b234f1fc7114",
+      "DocumentInstanceId": "f80c97a9-9b91-44d0-8f79-7deeca2db556",
+      "UserId": "78125579-a2b1-4463-9188-23208afcd1dd",
+      "Tenant": "FCD",
+      "AuditAction": "Delete",
+      "TimeStamp": "2022-11-18T15:21:31.964Z",
+      "Details": []
+    }
+  ],
+  "users": [
+    {
+      "UserId": "78125579-a2b1-4463-9188-23208afcd1dd",
+      "LoginId": "TheTestClientIdToDeleteDocument",
+      "Username": "Unresolved",
+      "DisplayName": "Unresolved",
+      "Type": "Service"
+    }
+  ]
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/AssertField/__snapshots__/AssertFieldTests.Match_AssertMultipleTwoFieldCompares_Success.snap.original
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/AssertField/__snapshots__/AssertFieldTests.Match_AssertMultipleTwoFieldCompares_Success.snap.original
@@ -1,0 +1,91 @@
+{
+  "result": {
+    "data": {
+      "deleteDocument": {
+        "success": true,
+        "errors": null
+      }
+    }
+  },
+  "docInstances": [
+    {
+      "Id": "f80c97a9-9b91-44d0-8f79-7deeca2db556",
+      "DocumentId": "49333741-ef79-4e5a-97bc-bf2cdd3f1efd",
+      "RefId": "7ed772a2-2c33-4720-986d-8a9655b33d15",
+      "Name": "Default test document small",
+      "Tenant": "FCD",
+      "IsDeleted": true,
+      "Created": "2019-05-28T08:20:37Z",
+      "Modified": "2019-05-28T09:20:37Z",
+      "CreatedBy": "cfc67d0b-9c3c-4e4d-af2e-57fd12efc78f",
+      "ModifiedBy": "ee0a3db2-3f9e-4ce2-8f3e-f0869f366983",
+      "Metadata": [
+        {
+          "Name": "Language",
+          "Value": "En"
+        },
+        {
+          "Name": "OfferType",
+          "Value": "TestOffer"
+        },
+        {
+          "Name": "ContractId",
+          "Value": "aa5756be-4f3c-4962-8ce7-d110f94a8627"
+        },
+        {
+          "Name": "Pages",
+          "Value": 2
+        },
+        {
+          "Name": "IsSent",
+          "Value": true
+        },
+        {
+          "Name": "LetterDate",
+          "Value": "2019-05-28T10:20:37Z"
+        }
+      ],
+      "MetadataAddition": []
+    }
+  ],
+  "changeSets": [
+    {
+      "Id": "b79eb661-10ec-4adf-b3e1-f25b08bb07a2",
+      "DocumentId": null,
+      "DocumentInstanceId": "f80c97a9-9b91-44d0-8f79-7deeca2db556",
+      "UserId": "78125579-a2b1-4463-9188-23208afcd1dd",
+      "Tenant": "FCD",
+      "ChangeDate": "2022-11-18T15:21:31.967Z",
+      "Changes": [
+        {
+          "Type": "Document",
+          "Action": "Deleted",
+          "Name": null,
+          "OldValue": null,
+          "NewValue": null
+        }
+      ],
+      "Infos": {}
+    }
+  ],
+  "audits": [
+    {
+      "Id": "e1dbc5fb-68c4-4c77-a48a-b234f1fc7114",
+      "DocumentInstanceId": "f80c97a9-9b91-44d0-8f79-7deeca2db556",
+      "UserId": "78125579-a2b1-4463-9188-23208afcd1dd",
+      "Tenant": "FCD",
+      "AuditAction": "Delete",
+      "TimeStamp": "2022-11-18T15:21:31.964Z",
+      "Details": []
+    }
+  ],
+  "users": [
+    {
+      "UserId": "78125579-a2b1-4463-9188-23208afcd1dd",
+      "LoginId": "TheTestClientIdToDeleteDocument",
+      "Username": "Unresolved",
+      "DisplayName": "Unresolved",
+      "Type": "Service"
+    }
+  ]
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/AssertField/__snapshots__/AssertFieldTests.Match_AssertTwoFieldsAgainstEachOtherWithinSnapshot_SuccessfulAssert.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/AssertField/__snapshots__/AssertFieldTests.Match_AssertTwoFieldsAgainstEachOtherWithinSnapshot_SuccessfulAssert.snap
@@ -1,0 +1,56 @@
+﻿{
+  "Id": "c78c698f-9ee5-4b4b-9a0e-ef729b1f8ec8",
+  "Firstname": "Mark",
+  "Lastname": "Walton",
+  "CreationDate": "2018-06-06T00:00:00",
+  "DateOfBirth": "2000-06-25T00:00:00",
+  "Age": 30,
+  "Size": 182.5214,
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  },
+  "Children": [
+    {
+      "Name": "James",
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": null,
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": "Hanna",
+      "DateOfBirth": "2012-03-20T00:00:00"
+    }
+  ],
+  "Relatives": [
+    {
+      "Id": "fcf04ca6-d8f2-4214-a3ff-d0ded5bad4de",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Size": 165.23,
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      },
+      "Children": [],
+      "Relatives": null
+    }
+  ]
+}

--- a/test/Snapshooter.Xunit.Tests/MatchOptions/AssertField/__snapshots__/AssertFieldTests.Match_AssertTwoRandomFieldsAgainstEachOtherWithinSnapshot_SuccessfulAssert.snap
+++ b/test/Snapshooter.Xunit.Tests/MatchOptions/AssertField/__snapshots__/AssertFieldTests.Match_AssertTwoRandomFieldsAgainstEachOtherWithinSnapshot_SuccessfulAssert.snap
@@ -1,0 +1,56 @@
+﻿{
+  "Id": "c80bbc32-82ba-49cf-b677-7c911930d99d",
+  "Firstname": "Mark",
+  "Lastname": "Walton",
+  "CreationDate": "2018-06-06T00:00:00",
+  "DateOfBirth": "2000-06-25T00:00:00",
+  "Age": 30,
+  "Size": 182.5214,
+  "Address": {
+    "Street": "Rohrstrasse",
+    "StreetNumber": 12,
+    "Plz": 8304,
+    "City": "Wallislellen",
+    "Country": {
+      "Name": "Switzerland",
+      "CountryCode": "CH"
+    }
+  },
+  "Children": [
+    {
+      "Name": "James",
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": null,
+      "DateOfBirth": "2015-02-12T00:00:00"
+    },
+    {
+      "Name": "Hanna",
+      "DateOfBirth": "2012-03-20T00:00:00"
+    }
+  ],
+  "Relatives": [
+    {
+      "Id": "c80bbc32-82ba-49cf-b677-7c911930d99d",
+      "Firstname": "Sandra",
+      "Lastname": "Schneider",
+      "CreationDate": "2019-04-01T00:00:00",
+      "DateOfBirth": "1996-02-14T00:00:00",
+      "Age": null,
+      "Size": 165.23,
+      "Address": {
+        "Street": "Bahnhofstrasse",
+        "StreetNumber": 450,
+        "Plz": 8000,
+        "City": "Zurich",
+        "Country": {
+          "Name": "Switzerland",
+          "CountryCode": "CH"
+        }
+      },
+      "Children": [],
+      "Relatives": null
+    }
+  ]
+}


### PR DESCRIPTION
If multiple field options were used within one match option, then only the field of the last specified field option path was ignored during the snapshot comparison. Therefore we could not use multiple field definitions within one match option.
