### PR TITLE
Fixing null handling for parameters

### DIFF
--- a/src/Snapshooter.MSTest/MSTestSnapshotFullNameReader.cs
+++ b/src/Snapshooter.MSTest/MSTestSnapshotFullNameReader.cs
@@ -132,7 +132,7 @@ namespace Snapshooter.MSTest
 
             return $"{method.DeclaringType.Name}." +
                 method.Name +
-                $"_{string.Join("_", currentRow.Data.Select(d => d.ToString()))}";
+                $"_{string.Join("_", currentRow.Data.Select(d => d is null ? "null" : d.ToString()))}";
         }
     }
 }

--- a/test/Snapshooter.MSTest.Tests/MSTestSnapshotFullNameReaderTests.cs
+++ b/test/Snapshooter.MSTest.Tests/MSTestSnapshotFullNameReaderTests.cs
@@ -118,6 +118,28 @@ namespace Snapshooter.MSTest.Tests
                 $"_{param1}_{param2}");
         }
 
+        [DataTestMethod]
+        [DataRow("testString1", 5)]
+        [DataRow("testString2", 6)]
+        [DataRow("testString3", null)]
+        public async Task ReadSnapshotFullName_ResolveTheorySnapshotNameAsync_NameResolvedWithNullParameters(
+           string param1, int? param2)
+        {
+            // arrange
+            var snapshotFullNameResolver = new MSTestSnapshotFullNameReader();
+            await Task.Delay(1);
+
+            // act
+            SnapshotFullName snapshotFullName = snapshotFullNameResolver.ReadSnapshotFullName();
+
+            // assert
+            await Task.Delay(1);
+            Assert.AreEqual(snapshotFullName.Filename,
+                $"{nameof(MSTestSnapshotFullNameReaderTests)}." +
+                $"{nameof(ReadSnapshotFullName_ResolveTheorySnapshotNameAsync_NameResolvedWithNullParameters)}" +
+                $"_{param1}_{(param2 is null ? "null" : param2)}");
+        }
+
         private static object[] TestCases => new object[]
         {
             new object[] { "testString1", 5 },


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

Null checking when generating snapshot name from params.

Addresses #178
