### PR TITLE
Add .NET 4.6.2 target

### DIFF
--- a/src/Dependencies.props
+++ b/src/Dependencies.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup Label="Framework Versions">
-    <ResourceProjectTargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0;net462</ResourceProjectTargetFrameworks>
+    <ResourceProjectTargetFrameworks>netstandard2.0;net462;net6.0;net7.0;net8.0</ResourceProjectTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/Dependencies.props
+++ b/src/Dependencies.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup Label="Framework Versions">
-    <ResourceProjectTargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</ResourceProjectTargetFrameworks>
+    <ResourceProjectTargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0;net462</ResourceProjectTargetFrameworks>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
NUnit 4 does not support .NET Standard 2.0 anymore,
so we need to stay on NUnit 3 when targeting .NET Standard.

This commit adds a dedicated .NET 4.6.2 target that uses NUnit 4.


Addresses #194 