### PR TITLE
Fix TUnit MethodNotFoundException

### DIFF
--- a/src/Snapshooter.TUnit/Snapshooter.TUnit.csproj
+++ b/src/Snapshooter.TUnit/Snapshooter.TUnit.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="TUnit.Assertions" Version="0.3.20" />
-    <PackageReference Include="TUnit.Core" Version="0.3.20" />
+    <PackageReference Include="TUnit.Assertions" Version="0.10.6" />
+    <PackageReference Include="TUnit.Core" Version="0.10.6" />
   </ItemGroup>
 
 </Project>

--- a/src/Snapshooter.TUnit/TUnitSnapshotFullNameReader.cs
+++ b/src/Snapshooter.TUnit/TUnitSnapshotFullNameReader.cs
@@ -98,7 +98,7 @@ namespace Snapshooter.TUnit
         {
             TestContext currentTestContext = TestContext.Current!;
 
-            var typeName = currentTestContext.TestDetails.ClassType.Name;
+            var typeName = currentTestContext.TestDetails.TestClass.Name;
             var methodName = currentTestContext.TestDetails.TestName;
             var parameters = SnapshotNameExtension.Create(currentTestContext.TestDetails.TestMethodArguments).ToParamsString();
 

--- a/test/Snapshooter.TUnit.Tests/Snapshooter.TUnit.Tests.csproj
+++ b/test/Snapshooter.TUnit.Tests/Snapshooter.TUnit.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="TUnit" Version="0.3.20" />
+    <PackageReference Include="TUnit" Version="0.10.6" />
   </ItemGroup>
 
 </Project>

--- a/test/Snapshooter.TUnit.Tests/TUnitAssertTests.cs
+++ b/test/Snapshooter.TUnit.Tests/TUnitAssertTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using TUnit.Assertions.AssertConditions.Throws;
 using TUnit.Assertions.Exceptions;
 
 namespace Snapshooter.TUnit.Tests


### PR DESCRIPTION
TUnit has had some refactorings since v0.3.

This fixes a method/property signature change.