### PR TITLE
Enhance snapshot naming and improve formatting utilities

### DIFF
--- a/src/Snapshooter.MSTest/MSTestSnapshotFullNameReader.cs
+++ b/src/Snapshooter.MSTest/MSTestSnapshotFullNameReader.cs
@@ -130,9 +130,8 @@ namespace Snapshooter.MSTest
             DataRowAttribute currentRow =
                 dataRowAttributes.ElementAt(dataTestMethodRowIndex[method.Name]);
 
-            return $"{method.DeclaringType.Name}." +
-                method.Name +
-                $"_{string.Join("_", currentRow.Data.Select(d => d.ToString()))}";
+            return $"{method.DeclaringType.Name}.{method.Name}" +
+                SnapshotNameExtension.Create(currentRow.Data).ToParamsString();
         }
     }
 }

--- a/src/Snapshooter/Core/MatchOperators/AcceptMatchOperator.cs
+++ b/src/Snapshooter/Core/MatchOperators/AcceptMatchOperator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Snapshooter.Exceptions;
@@ -137,7 +138,7 @@ namespace Snapshooter.Core
             }
         }
 
-        private string CreateAcceptExceptionMessage(
+        private static string CreateAcceptExceptionMessage(
             string path, object field, string message)
         {
             return
@@ -147,9 +148,16 @@ namespace Snapshooter.Core
                 $"{message}";
         }
 
-        private string GetAcceptFieldValueString(object field)
+        private static string GetAcceptFieldValueString(object field)
         {
-            return field is { } ? field.ToString() : "Null";
+            return field switch
+            {
+                null => "Null",
+                decimal decimalValue => decimalValue.ToString(CultureInfo.InvariantCulture),
+                double doubleValue => doubleValue.ToString(CultureInfo.InvariantCulture),
+                float floatValue => floatValue.ToString(CultureInfo.InvariantCulture),
+                _ => field.ToString()
+            };
         }
     }
 }

--- a/test/Snapshooter.Xunit.Tests/AcceptMatchOption/TestHelpers/AcceptAssert.cs
+++ b/test/Snapshooter.Xunit.Tests/AcceptMatchOption/TestHelpers/AcceptAssert.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Snapshooter.Core;
 using Snapshooter.Exceptions;
 using Xunit;
+using System.Globalization;
 
 #nullable enable
 
@@ -62,9 +63,18 @@ namespace Snapshooter.Xunit.Tests.AcceptMatchOption.TestHelpers
                 Assert.Equal(exception.Message,
                     $"Accept match option failed, " +
                     $"because the field value of '{nameof(testee.Value)}' " +
-                    $"is '{testeeValue ?? testee.Value!.ToString()}', " +
+                    $"is '{testeeValue ?? FormatInvariant(testee.Value)}', " +
                     $"and therefore not of type '{typeName}'.");
             }
+        }
+
+        private static string FormatInvariant(object? value)
+        {
+            if (value == null) return "Null";
+            if (value is decimal d) return d.ToString(CultureInfo.InvariantCulture);
+            if (value is double db) return db.ToString(CultureInfo.InvariantCulture);
+            if (value is float f) return f.ToString(CultureInfo.InvariantCulture);
+            return value.ToString()!;
         }
     }
 }

--- a/test/Snapshooter.Xunit3.Tests/AcceptMatchOption/TestHelpers/AcceptAssert.cs
+++ b/test/Snapshooter.Xunit3.Tests/AcceptMatchOption/TestHelpers/AcceptAssert.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Snapshooter.Core;
 using Snapshooter.Exceptions;
 using Xunit;
+using System.Globalization;
 
 #nullable enable
 
@@ -62,9 +63,18 @@ namespace Snapshooter.Xunit3.Tests.AcceptMatchOption.TestHelpers
                 Assert.Equal(exception.Message,
                     $"Accept match option failed, " +
                     $"because the field value of '{nameof(testee.Value)}' " +
-                    $"is '{testeeValue ?? testee.Value!.ToString()}', " +
+                    $"is '{testeeValue ?? FormatInvariant(testee.Value)}', " +
                     $"and therefore not of type '{typeName}'.");
             }
+        }
+
+        private static string FormatInvariant(object? value)
+        {
+            if (value == null) return "Null";
+            if (value is decimal d) return d.ToString(CultureInfo.InvariantCulture);
+            if (value is double db) return db.ToString(CultureInfo.InvariantCulture);
+            if (value is float f) return f.ToString(CultureInfo.InvariantCulture);
+            return value.ToString()!;
         }
     }
 }


### PR DESCRIPTION
This pull request improves the handling and formatting of numeric values for snapshot names and exception messages, ensuring consistency and culture-invariant representations throughout the codebase. It also refactors some methods for clarity and static usage, and updates related test helpers to match the new formatting logic.

### Numeric value formatting improvements

* Updated `GetAcceptFieldValueString` in `AcceptMatchOperator.cs` to format `decimal`, `double`, and `float` values using `CultureInfo.InvariantCulture`, ensuring consistent string representations regardless of locale.
* Added similar `FormatInvariant` helper methods to both `AcceptAssert.cs` test helper files to ensure test exception messages use invariant formatting for numeric types. [[1]](diffhunk://#diff-c7c84199253b2a0ca07cdb540944daf509f0436e9ae96b9d427a526ff0fd4cf6L65-R78) [[2]](diffhunk://#diff-aa93cdd9f0faf8d68920d489b2bf615bf799a076c167757aefed270140d006b2L65-R78)

### Refactoring and static method updates

* Changed `CreateAcceptExceptionMessage` and `GetAcceptFieldValueString` in `AcceptMatchOperator.cs` from instance methods to static methods for better clarity and usage. [[1]](diffhunk://#diff-057965fad18957544e56d076988957ea22af0515cef59ff8393765552b5d1751L140-R141) [[2]](diffhunk://#diff-057965fad18957544e56d076988957ea22af0515cef59ff8393765552b5d1751L150-R160)

### Snapshot name generation enhancement

* Modified `GetMethodSnapshotName` in `MSTestSnapshotFullNameReader.cs` to use `SnapshotNameExtension.Create(...).ToParamsString()` for more robust and flexible snapshot naming, especially for parameterized tests.

### Dependency updates

* Added `System.Globalization` imports to files that handle culture-invariant formatting for numeric values. [[1]](diffhunk://#diff-057965fad18957544e56d076988957ea22af0515cef59ff8393765552b5d1751R3) [[2]](diffhunk://#diff-c7c84199253b2a0ca07cdb540944daf509f0436e9ae96b9d427a526ff0fd4cf6R9) [[3]](diffhunk://#diff-aa93cdd9f0faf8d68920d489b2bf615bf799a076c167757aefed270140d006b2R9)