### PR TITLE
MSTest: Use invariant culture conversion for snapshot name generation.

### DIFF
--- a/src/Snapshooter.MSTest/MSTestSnapshotFullNameReader.cs
+++ b/src/Snapshooter.MSTest/MSTestSnapshotFullNameReader.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -132,7 +132,7 @@ namespace Snapshooter.MSTest
 
             return $"{method.DeclaringType.Name}." +
                 method.Name +
-                $"_{string.Join("_", currentRow.Data.Select(d => d.ToString()))}";
+                $"_{string.Join("_", currentRow.Data.Select(d => Convert.ToString(d, CultureInfo.InvariantCulture)))}";
         }
     }
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Use invariant culture conversion for snapshot name generation.
- The issue might exist for the other test frameworks aswell, I didn´t look at them right now

Addresses #221 (in this specific format)
