### PR TITLE
fix: update MSTest package references and target framework versions

### DIFF
--- a/src/Snapshooter.MSTest/Snapshooter.MSTest.csproj
+++ b/src/Snapshooter.MSTest/Snapshooter.MSTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <AssemblyName>Snapshooter.MSTest</AssemblyName>
     <RootNamespace>Snapshooter.MSTest</RootNamespace>
     <PackageId>Snapshooter.MSTest</PackageId>
@@ -12,8 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.1" />
+    <PackageReference Include="MSTest" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Snapshooter.MSTest.Tests/Snapshooter.MSTest.Tests.csproj
+++ b/test/Snapshooter.MSTest.Tests/Snapshooter.MSTest.Tests.csproj
@@ -6,11 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Snapshooter.MSTest\Snapshooter.MSTest.csproj" />
     <ProjectReference Include="..\Snapshooter.Tests.Data\Snapshooter.Tests.Data.csproj" />
   </ItemGroup>

--- a/test/Test.props
+++ b/test/Test.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Condition="'$(MSBuildProjectName)' != 'Snapshooter.TUnit.Tests'" Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Condition="'$(MSBuildProjectName)' != 'Snapshooter.TUnit.Tests'" Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />


### PR DESCRIPTION
Fixes #219 

This pull request updates the MSTest integration in the Snapshooter project to support newer .NET versions and simplifies MSTest package dependencies. It also upgrades the test SDK version for improved compatibility and features.

**.NET and MSTest Support Updates:**

* Updated `Snapshooter.MSTest` to target .NET 8.0, 9.0, and 10.0, expanding compatibility with the latest .NET versions.
* Replaced separate `MSTest.TestAdapter` and `MSTest.TestFramework` dependencies with the unified `MSTest` package (version 4.1.0) in `Snapshooter.MSTest`, simplifying dependency management.
* Removed explicit MSTest package references from `Snapshooter.MSTest.Tests`, relying on the updated project references for test projects.

**Test SDK Upgrade:**

* Upgraded `Microsoft.NET.Test.Sdk` from version 17.3.2 to 18.0.1 in the shared test properties to ensure compatibility with newer .NET versions and test features.