### PR TITLE
Improve NRT Annotations

### DIFF
--- a/src/Snapshooter.Json/Snapshot.cs
+++ b/src/Snapshooter.Json/Snapshot.cs
@@ -28,7 +28,8 @@ namespace Snapshooter.Json
         /// </param>
         public static void Match<T>(T currentResult,
                                     string snapshotName,
-                                    Func<MatchOptions, MatchOptions> matchOptions = null)
+                                    Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotName, matchOptions);
         }
@@ -59,7 +60,8 @@ namespace Snapshooter.Json
         public static void Match<T>(T currentResult,
                                     string snapshotName,
                                     SnapshotNameExtension snapshotNameExtension,
-                                    Func<MatchOptions, MatchOptions> matchOptions = null)
+                                    Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotName, snapshotNameExtension, matchOptions);
         }
@@ -79,7 +81,7 @@ namespace Snapshooter.Json
         /// </param>
         public static void Match(object currentResult,
                                  string snapshotName,
-                                 Func<MatchOptions, MatchOptions> matchOptions = null)
+                                 Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             SnapshotFullName snapshotFullName = FullName(snapshotName);
             Snapshooter.AssertSnapshot(currentResult, snapshotFullName, matchOptions);
@@ -111,7 +113,7 @@ namespace Snapshooter.Json
         public static void Match(object currentResult,
                                  string snapshotName,
                                  SnapshotNameExtension snapshotNameExtension,
-                                 Func<MatchOptions, MatchOptions> matchOptions = null)
+                                 Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             SnapshotFullName snapshotFullName = FullName(snapshotName, snapshotNameExtension);
             Snapshooter.AssertSnapshot(currentResult, snapshotFullName, matchOptions);

--- a/src/Snapshooter.MSTest/MSTestSnapshotFullNameReader.cs
+++ b/src/Snapshooter.MSTest/MSTestSnapshotFullNameReader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -27,11 +28,11 @@ namespace Snapshooter.MSTest
         /// <returns>The full name of the snapshot.</returns>
         public SnapshotFullName ReadSnapshotFullName()
         {
-            SnapshotFullName snapshotFullName = null;
+            SnapshotFullName? snapshotFullName = null;
             StackFrame[] stackFrames = new StackTrace(true).GetFrames();
             foreach (StackFrame stackFrame in stackFrames)
             {
-                MethodBase method = stackFrame.GetMethod();
+                MethodBase? method = stackFrame.GetMethod();
                 if (IsMSTestTest(method))
                 {
                     snapshotFullName = new SnapshotFullName(
@@ -41,7 +42,7 @@ namespace Snapshooter.MSTest
                     break;
                 }
 
-                MethodBase asyncMethod = EvaluateAsynchronMethodBase(method);
+                MethodBase? asyncMethod = EvaluateAsynchronMethodBase(method);
                 if (IsMSTestTest(asyncMethod))
                 {
                     snapshotFullName = new SnapshotFullName(
@@ -69,7 +70,7 @@ namespace Snapshooter.MSTest
             return snapshotFullName;
         }
 
-        private static bool IsMSTestTest(MemberInfo method)
+        private static bool IsMSTestTest([NotNullWhen(true)] MemberInfo? method)
         {
             bool isFactTest = IsTestMethodTestMethod(method);
             bool isTheoryTest = IsDataTestMethodTestMethod(method);
@@ -77,22 +78,22 @@ namespace Snapshooter.MSTest
             return isFactTest || isTheoryTest;
         }
 
-        private static bool IsTestMethodTestMethod(MemberInfo method)
+        private static bool IsTestMethodTestMethod([NotNullWhen(true)] MemberInfo? method)
         {
             return method?.GetCustomAttributes(typeof(TestMethodAttribute))?.Any() ?? false;
         }
 
-        private static bool IsDataTestMethodTestMethod(MemberInfo method)
+        private static bool IsDataTestMethodTestMethod([NotNullWhen(true)] MemberInfo? method)
         {
             return method?.GetCustomAttributes(typeof(DataTestMethodAttribute))?.Any() ?? false;
         }
 
-        private static MethodBase EvaluateAsynchronMethodBase(MemberInfo method)
+        private static MethodBase? EvaluateAsynchronMethodBase(MemberInfo? method)
         {
-            Type methodDeclaringType = method?.DeclaringType;
-            Type classDeclaringType = methodDeclaringType?.DeclaringType;
+            Type? methodDeclaringType = method?.DeclaringType;
+            Type? classDeclaringType = methodDeclaringType?.DeclaringType;
 
-            MethodInfo actualMethodInfo = null;
+            MethodInfo? actualMethodInfo = null;
             if (classDeclaringType != null)
             {
                 IEnumerable<MethodInfo> selectedMethodInfos =
@@ -141,7 +142,7 @@ namespace Snapshooter.MSTest
                 $"_{string.Join("_", currentRow.Data.Select(ParamDataFormatter))}";
         }
 
-        private static string ParamDataFormatter(object data) => data switch
+        private static string? ParamDataFormatter(object? data) => data switch
         {
             null => "null",
             string s => s,

--- a/src/Snapshooter.MSTest/Snapshot.cs
+++ b/src/Snapshooter.MSTest/Snapshot.cs
@@ -29,7 +29,8 @@ namespace Snapshooter.MSTest
         /// </param>
         public static void Match<T>(
             T currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, matchOptions);
         }
@@ -57,7 +58,8 @@ namespace Snapshooter.MSTest
         public static void Match<T>(
             T currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotNameExtension, matchOptions);
         }
@@ -80,7 +82,8 @@ namespace Snapshooter.MSTest
         public static void Match<T>(
             T currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotName, matchOptions);
         }
@@ -113,7 +116,8 @@ namespace Snapshooter.MSTest
             T currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotName, snapshotNameExtension, matchOptions);
         }
@@ -133,7 +137,8 @@ namespace Snapshooter.MSTest
         public static void Match<T>(
             T currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotFullName, matchOptions);
         }
@@ -150,7 +155,7 @@ namespace Snapshooter.MSTest
         /// </param>
         public static void Match(
             object currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             try
             {
@@ -184,7 +189,7 @@ namespace Snapshooter.MSTest
         public static void Match(
             object currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(snapshotNameExtension), matchOptions);
         }
@@ -206,7 +211,7 @@ namespace Snapshooter.MSTest
         public static void Match(
             object currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(snapshotName), matchOptions);
         }
@@ -238,7 +243,7 @@ namespace Snapshooter.MSTest
             object currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(snapshotName, snapshotNameExtension), matchOptions);
         }
@@ -258,7 +263,7 @@ namespace Snapshooter.MSTest
         public static void Match(
             object currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             try
             {
@@ -276,7 +281,7 @@ namespace Snapshooter.MSTest
         /// <returns>The full name of a snapshot.</returns>
         public static SnapshotFullName FullName()
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {
@@ -299,7 +304,7 @@ namespace Snapshooter.MSTest
         /// <returns>The full name of a snapshot.</returns>
         public static SnapshotFullName FullName(string snapshotName)
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {
@@ -328,7 +333,7 @@ namespace Snapshooter.MSTest
         public static SnapshotFullName FullName(
             SnapshotNameExtension snapshotNameExtension)
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {
@@ -363,7 +368,7 @@ namespace Snapshooter.MSTest
         public static SnapshotFullName FullName(
             string snapshotName, SnapshotNameExtension snapshotNameExtension)
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {

--- a/src/Snapshooter.MSTest/SnapshotExtension.cs
+++ b/src/Snapshooter.MSTest/SnapshotExtension.cs
@@ -16,7 +16,7 @@ namespace Snapshooter.MSTest
         /// </param>
         public static void MatchSnapshot(
             this object currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, matchOptions);
@@ -44,7 +44,7 @@ namespace Snapshooter.MSTest
         public static void MatchSnapshot(
             this object currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotNameExtension, matchOptions);
@@ -67,7 +67,7 @@ namespace Snapshooter.MSTest
         public static void MatchSnapshot(
             this object currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotName, matchOptions);
@@ -100,7 +100,7 @@ namespace Snapshooter.MSTest
             this object currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotName, snapshotNameExtension, matchOptions);
@@ -122,7 +122,7 @@ namespace Snapshooter.MSTest
         public static void MatchSnapshot(
             this object currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotFullName, matchOptions);

--- a/src/Snapshooter.NUnit/NUnitSnapshotFullNameReader.cs
+++ b/src/Snapshooter.NUnit/NUnitSnapshotFullNameReader.cs
@@ -27,11 +27,11 @@ namespace Snapshooter.NUnit
         /// <returns>The full name of the snapshot.</returns>
         public SnapshotFullName ReadSnapshotFullName()
         {
-            SnapshotFullName snapshotFullName = null;
+            SnapshotFullName? snapshotFullName = null;
             StackFrame[] stackFrames = new StackTrace(true).GetFrames();
             foreach (StackFrame stackFrame in stackFrames)
             {
-                MethodBase method = stackFrame.GetMethod();
+                MethodBase? method = stackFrame.GetMethod();
                 if (IsNUnitTestMethod(method))
                 {
                     snapshotFullName = new SnapshotFullName(
@@ -41,7 +41,7 @@ namespace Snapshooter.NUnit
                     break;
                 }
 
-                MethodBase asyncMethod = EvaluateAsynchronMethodBase(method);
+                MethodBase? asyncMethod = EvaluateAsynchronMethodBase(method);
                 if (IsNUnitTestMethod(asyncMethod))
                 {
                     snapshotFullName = new SnapshotFullName(
@@ -69,7 +69,7 @@ namespace Snapshooter.NUnit
             return snapshotFullName;
         }
 
-        private static bool IsNUnitTestMethod(MemberInfo method)
+        private static bool IsNUnitTestMethod(MemberInfo? method)
         {
             bool isFactTest = IsTestMethod(method);
             bool isTheoryTest = IsTestCaseTestMethod(method);
@@ -78,27 +78,27 @@ namespace Snapshooter.NUnit
             return isFactTest || isTheoryTest || isTheoryDataTest;
         }
 
-        private static bool IsTestMethod(MemberInfo method)
+        private static bool IsTestMethod(MemberInfo? method)
         {
             return method?.GetCustomAttributes(typeof(TestAttribute))?.Any() ?? false;
         }
 
-        private static bool IsTestCaseTestMethod(MemberInfo method)
+        private static bool IsTestCaseTestMethod(MemberInfo? method)
         {
             return method?.GetCustomAttributes(typeof(TestCaseAttribute))?.Any() ?? false;
         }
 
-        private static bool IsTestCaseSourceTestMethod(MemberInfo method)
+        private static bool IsTestCaseSourceTestMethod(MemberInfo? method)
         {
             return method?.GetCustomAttributes(typeof(TestCaseSourceAttribute))?.Any() ?? false;
         }
 
-        private static MethodBase EvaluateAsynchronMethodBase(MemberInfo method)
+        private static MethodBase? EvaluateAsynchronMethodBase(MemberInfo? method)
         {
-            Type methodDeclaringType = method?.DeclaringType;
-            Type classDeclaringType = methodDeclaringType?.DeclaringType;
+            Type? methodDeclaringType = method?.DeclaringType;
+            Type? classDeclaringType = methodDeclaringType?.DeclaringType;
 
-            MethodInfo actualMethodInfo = null;
+            MethodInfo? actualMethodInfo = null;
             if (classDeclaringType != null)
             {
                 IEnumerable<MethodInfo> selectedMethodInfos =

--- a/src/Snapshooter.NUnit/Snapshot.cs
+++ b/src/Snapshooter.NUnit/Snapshot.cs
@@ -30,7 +30,8 @@ namespace Snapshooter.NUnit
         /// </param>
         public static void Match<T>(
             T currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, matchOptions);
         }
@@ -58,7 +59,8 @@ namespace Snapshooter.NUnit
         public static void Match<T>(
             T currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotNameExtension, matchOptions);
         }
@@ -81,7 +83,8 @@ namespace Snapshooter.NUnit
         public static void Match<T>(
             T currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotName, matchOptions);
         }
@@ -114,7 +117,8 @@ namespace Snapshooter.NUnit
             T currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotName, snapshotNameExtension, matchOptions);
         }
@@ -134,7 +138,8 @@ namespace Snapshooter.NUnit
         public static void Match<T>(
             T currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotFullName, matchOptions);
         }
@@ -151,7 +156,7 @@ namespace Snapshooter.NUnit
         /// </param>
         public static void Match(
             object currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(), matchOptions);
         }
@@ -178,7 +183,7 @@ namespace Snapshooter.NUnit
         public static void Match(
             object currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(snapshotNameExtension), matchOptions);
         }
@@ -200,7 +205,7 @@ namespace Snapshooter.NUnit
         public static void Match(
             object currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(snapshotName), matchOptions);
         }
@@ -232,7 +237,7 @@ namespace Snapshooter.NUnit
             object currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(snapshotName, snapshotNameExtension), matchOptions);
         }
@@ -252,7 +257,7 @@ namespace Snapshooter.NUnit
         public static void Match(
             object currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             try
             {
@@ -273,7 +278,7 @@ namespace Snapshooter.NUnit
         /// <returns>The full name of a snapshot.</returns>
         public static SnapshotFullName FullName()
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {
@@ -296,7 +301,7 @@ namespace Snapshooter.NUnit
         /// <returns>The full name of a snapshot.</returns>
         public static SnapshotFullName FullName(string snapshotName)
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {
@@ -325,7 +330,7 @@ namespace Snapshooter.NUnit
         public static SnapshotFullName FullName(
             SnapshotNameExtension snapshotNameExtension)
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {
@@ -360,7 +365,7 @@ namespace Snapshooter.NUnit
         public static SnapshotFullName FullName(
             string snapshotName, SnapshotNameExtension snapshotNameExtension)
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {

--- a/src/Snapshooter.NUnit/SnapshotExtension.cs
+++ b/src/Snapshooter.NUnit/SnapshotExtension.cs
@@ -16,7 +16,7 @@ namespace Snapshooter.NUnit
         /// </param>
         public static void MatchSnapshot(
             this object currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, matchOptions);
@@ -44,7 +44,7 @@ namespace Snapshooter.NUnit
         public static void MatchSnapshot(
             this object currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotNameExtension, matchOptions);
@@ -67,7 +67,7 @@ namespace Snapshooter.NUnit
         public static void MatchSnapshot(
             this object currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotName, matchOptions);
@@ -100,7 +100,7 @@ namespace Snapshooter.NUnit
             this object currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotName, snapshotNameExtension, matchOptions);
@@ -122,7 +122,7 @@ namespace Snapshooter.NUnit
         public static void MatchSnapshot(
             this object currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotFullName, matchOptions);

--- a/src/Snapshooter.TUnit/Snapshot.cs
+++ b/src/Snapshooter.TUnit/Snapshot.cs
@@ -30,7 +30,8 @@ namespace Snapshooter.TUnit
         /// </param>
         public static void Match<T>(
             T currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, matchOptions);
         }
@@ -58,7 +59,8 @@ namespace Snapshooter.TUnit
         public static void Match<T>(
             T currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotNameExtension, matchOptions);
         }
@@ -81,7 +83,8 @@ namespace Snapshooter.TUnit
         public static void Match<T>(
             T currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotName, matchOptions);
         }
@@ -114,7 +117,8 @@ namespace Snapshooter.TUnit
             T currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotName, snapshotNameExtension, matchOptions);
         }
@@ -134,7 +138,8 @@ namespace Snapshooter.TUnit
         public static void Match<T>(
             T currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotFullName, matchOptions);
         }
@@ -151,7 +156,7 @@ namespace Snapshooter.TUnit
         /// </param>
         public static void Match(
             object currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(), matchOptions);
         }
@@ -178,7 +183,7 @@ namespace Snapshooter.TUnit
         public static void Match(
             object currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(snapshotNameExtension), matchOptions);
         }
@@ -200,7 +205,7 @@ namespace Snapshooter.TUnit
         public static void Match(
             object currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(snapshotName), matchOptions);
         }
@@ -232,7 +237,7 @@ namespace Snapshooter.TUnit
             object currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(snapshotName, snapshotNameExtension), matchOptions);
         }
@@ -252,7 +257,7 @@ namespace Snapshooter.TUnit
         public static void Match(
             object currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             try
             {
@@ -273,7 +278,7 @@ namespace Snapshooter.TUnit
         /// <returns>The full name of a snapshot.</returns>
         public static SnapshotFullName FullName()
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {
@@ -296,7 +301,7 @@ namespace Snapshooter.TUnit
         /// <returns>The full name of a snapshot.</returns>
         public static SnapshotFullName FullName(string snapshotName)
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {
@@ -325,7 +330,7 @@ namespace Snapshooter.TUnit
         public static SnapshotFullName FullName(
             SnapshotNameExtension snapshotNameExtension)
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {
@@ -360,7 +365,7 @@ namespace Snapshooter.TUnit
         public static SnapshotFullName FullName(
             string snapshotName, SnapshotNameExtension snapshotNameExtension)
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {

--- a/src/Snapshooter.TUnit/SnapshotExtension.cs
+++ b/src/Snapshooter.TUnit/SnapshotExtension.cs
@@ -16,7 +16,7 @@ namespace Snapshooter.TUnit
         /// </param>
         public static void MatchSnapshot(
             this object currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, matchOptions);
@@ -44,7 +44,7 @@ namespace Snapshooter.TUnit
         public static void MatchSnapshot(
             this object currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotNameExtension, matchOptions);
@@ -67,7 +67,7 @@ namespace Snapshooter.TUnit
         public static void MatchSnapshot(
             this object currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotName, matchOptions);
@@ -100,7 +100,7 @@ namespace Snapshooter.TUnit
             this object currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotName, snapshotNameExtension, matchOptions);
@@ -122,7 +122,7 @@ namespace Snapshooter.TUnit
         public static void MatchSnapshot(
             this object currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotFullName, matchOptions);

--- a/src/Snapshooter.TUnit/TUnitSnapshotFullNameReader.cs
+++ b/src/Snapshooter.TUnit/TUnitSnapshotFullNameReader.cs
@@ -24,11 +24,11 @@ namespace Snapshooter.TUnit
         /// <returns>The full name of the snapshot.</returns>
         public SnapshotFullName ReadSnapshotFullName()
         {
-            SnapshotFullName snapshotFullName = null;
+            SnapshotFullName? snapshotFullName = null;
             StackFrame[] stackFrames = new StackTrace(true).GetFrames();
             foreach (StackFrame stackFrame in stackFrames)
             {
-                MethodBase method = stackFrame.GetMethod();
+                MethodBase? method = stackFrame.GetMethod();
                 if (IsTUnitTestMethod(method))
                 {
                     snapshotFullName = new SnapshotFullName(
@@ -38,7 +38,7 @@ namespace Snapshooter.TUnit
                     break;
                 }
 
-                MethodBase asyncMethod = EvaluateAsynchronousMethodBase(method);
+                MethodBase? asyncMethod = EvaluateAsynchronousMethodBase(method);
                 if (IsTUnitTestMethod(asyncMethod))
                 {
                     snapshotFullName = new SnapshotFullName(
@@ -66,17 +66,17 @@ namespace Snapshooter.TUnit
             return snapshotFullName;
         }
 
-        private static bool IsTUnitTestMethod(MemberInfo method)
+        private static bool IsTUnitTestMethod(MemberInfo? method)
         {
             return method?.GetCustomAttributes(typeof(TestAttribute)).Any() ?? false;
         }
 
-        private static MethodBase EvaluateAsynchronousMethodBase(MemberInfo method)
+        private static MethodBase? EvaluateAsynchronousMethodBase(MemberInfo? method)
         {
-            Type methodDeclaringType = method?.DeclaringType;
-            Type classDeclaringType = methodDeclaringType?.DeclaringType;
+            Type? methodDeclaringType = method?.DeclaringType;
+            Type? classDeclaringType = methodDeclaringType?.DeclaringType;
 
-            MethodInfo actualMethodInfo = null;
+            MethodInfo? actualMethodInfo = null;
             if (classDeclaringType != null)
             {
                 IEnumerable<MethodInfo> selectedMethodInfos =

--- a/src/Snapshooter.Xunit/Snapshot.cs
+++ b/src/Snapshooter.Xunit/Snapshot.cs
@@ -30,7 +30,8 @@ namespace Snapshooter.Xunit
         /// </param>
         public static void Match<T>(
             T currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, matchOptions);
         }
@@ -58,7 +59,8 @@ namespace Snapshooter.Xunit
         public static void Match<T>(
             T currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotNameExtension, matchOptions);
         }
@@ -81,7 +83,8 @@ namespace Snapshooter.Xunit
         public static void Match<T>(
             T currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotName, matchOptions);
         }
@@ -114,7 +117,8 @@ namespace Snapshooter.Xunit
             T currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotName, snapshotNameExtension, matchOptions);
         }
@@ -134,7 +138,8 @@ namespace Snapshooter.Xunit
         public static void Match<T>(
             T currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
+            where T : notnull
         {
             Match((object)currentResult, snapshotFullName, matchOptions);
         }
@@ -151,7 +156,7 @@ namespace Snapshooter.Xunit
         /// </param>
         public static void Match(
             object currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             try
             {
@@ -185,7 +190,7 @@ namespace Snapshooter.Xunit
         public static void Match(
             object currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(snapshotNameExtension), matchOptions);
         }
@@ -207,7 +212,7 @@ namespace Snapshooter.Xunit
         public static void Match(
             object currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(snapshotName), matchOptions);
         }
@@ -239,7 +244,7 @@ namespace Snapshooter.Xunit
             object currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             Match(currentResult, FullName(snapshotName, snapshotNameExtension), matchOptions);
         }
@@ -259,7 +264,7 @@ namespace Snapshooter.Xunit
         public static void Match(
             object currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             try
             {
@@ -277,7 +282,7 @@ namespace Snapshooter.Xunit
         /// <returns>The full name of a snapshot.</returns>
         public static SnapshotFullName FullName()
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {
@@ -300,7 +305,7 @@ namespace Snapshooter.Xunit
         /// <returns>The full name of a snapshot.</returns>
         public static SnapshotFullName FullName(string snapshotName)
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {
@@ -329,7 +334,7 @@ namespace Snapshooter.Xunit
         public static SnapshotFullName FullName(
             SnapshotNameExtension snapshotNameExtension)
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {
@@ -364,7 +369,7 @@ namespace Snapshooter.Xunit
         public static SnapshotFullName FullName(
             string snapshotName, SnapshotNameExtension snapshotNameExtension)
         {
-            SnapshotFullName fullName = _snapshotName.Value;
+            SnapshotFullName? fullName = _snapshotName.Value;
 
             if (fullName is null)
             {

--- a/src/Snapshooter.Xunit/SnapshotExtension.cs
+++ b/src/Snapshooter.Xunit/SnapshotExtension.cs
@@ -16,7 +16,7 @@ namespace Snapshooter.Xunit
         /// </param>
         public static void MatchSnapshot(
             this object currentResult,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, matchOptions);
@@ -44,7 +44,7 @@ namespace Snapshooter.Xunit
         public static void MatchSnapshot(
             this object currentResult,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotNameExtension, matchOptions);
@@ -67,7 +67,7 @@ namespace Snapshooter.Xunit
         public static void MatchSnapshot(
             this object currentResult,
             string snapshotName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotName, matchOptions);
@@ -100,7 +100,7 @@ namespace Snapshooter.Xunit
             this object currentResult,
             string snapshotName,
             SnapshotNameExtension snapshotNameExtension,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotName, snapshotNameExtension, matchOptions);
@@ -122,7 +122,7 @@ namespace Snapshooter.Xunit
         public static void MatchSnapshot(
             this object currentResult,
             SnapshotFullName snapshotFullName,
-            Func<MatchOptions, MatchOptions> matchOptions = null)
+            Func<MatchOptions, MatchOptions>? matchOptions = null)
         {
             var cleanedObject = currentResult.RemoveUnwantedWrappers();
             Snapshot.Match(cleanedObject, snapshotFullName, matchOptions);

--- a/src/Snapshooter.Xunit/XunitSnapshotFullNameReader.cs
+++ b/src/Snapshooter.Xunit/XunitSnapshotFullNameReader.cs
@@ -23,12 +23,12 @@ namespace Snapshooter.Xunit
         /// <returns>The full name of the snapshot.</returns>
         public SnapshotFullName ReadSnapshotFullName()
         {
-            SnapshotFullName snapshotFullName = null;
+            SnapshotFullName? snapshotFullName = null;
             StackFrame[] stackFrames = new StackTrace(true).GetFrames();
 
             foreach (StackFrame stackFrame in stackFrames)
             {
-                MethodBase method = stackFrame.GetMethod();
+                MethodBase? method = stackFrame.GetMethod();
                 if (IsXunitTestMethod(method))
                 {
                     snapshotFullName = new SnapshotFullName(
@@ -38,7 +38,7 @@ namespace Snapshooter.Xunit
                     break;
                 }
 
-                MethodBase asyncMethod = EvaluateAsynchronMethodBase(method);
+                MethodBase? asyncMethod = EvaluateAsynchronMethodBase(method);
                 if (IsXunitTestMethod(asyncMethod))
                 {
                     snapshotFullName = new SnapshotFullName(
@@ -66,7 +66,7 @@ namespace Snapshooter.Xunit
             return snapshotFullName;
         }
 
-        private static bool IsXunitTestMethod(MemberInfo method)
+        private static bool IsXunitTestMethod(MemberInfo? method)
         {
             bool isFactTest = IsFactTestMethod(method);
             bool isTheoryTest = IsTheoryTestMethod(method);
@@ -74,22 +74,22 @@ namespace Snapshooter.Xunit
             return isFactTest || isTheoryTest;
         }
 
-        private static bool IsFactTestMethod(MemberInfo method)
+        private static bool IsFactTestMethod(MemberInfo? method)
         {
             return method?.GetCustomAttributes(typeof(FactAttribute))?.Any() ?? false;
         }
 
-        private static bool IsTheoryTestMethod(MemberInfo method)
+        private static bool IsTheoryTestMethod(MemberInfo? method)
         {
             return method?.GetCustomAttributes(typeof(TheoryAttribute))?.Any() ?? false;
         }
 
-        private static MethodBase EvaluateAsynchronMethodBase(MemberInfo method)
+        private static MethodBase? EvaluateAsynchronMethodBase(MemberInfo? method)
         {
-            Type methodDeclaringType = method?.DeclaringType;
-            Type classDeclaringType = methodDeclaringType?.DeclaringType;
+            Type? methodDeclaringType = method?.DeclaringType;
+            Type? classDeclaringType = methodDeclaringType?.DeclaringType;
 
-            MethodInfo actualMethodInfo = null;
+            MethodInfo? actualMethodInfo = null;
             if (classDeclaringType != null)
             {
                 IEnumerable<MethodInfo> selectedMethodInfos =

--- a/src/Snapshooter.Xunit3/Snapshot.cs
+++ b/src/Snapshooter.Xunit3/Snapshot.cs
@@ -30,7 +30,8 @@ public static class Snapshot
     /// </param>
     public static void Match<T>(
         T currentResult,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
+        where T : notnull
     {
         Match((object)currentResult, matchOptions);
     }
@@ -58,7 +59,8 @@ public static class Snapshot
     public static void Match<T>(
         T currentResult,
         SnapshotNameExtension snapshotNameExtension,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
+        where T : notnull
     {
         Match((object)currentResult, snapshotNameExtension, matchOptions);
     }
@@ -81,7 +83,8 @@ public static class Snapshot
     public static void Match<T>(
         T currentResult,
         string snapshotName,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
+        where T : notnull
     {
         Match((object)currentResult, snapshotName, matchOptions);
     }
@@ -114,7 +117,8 @@ public static class Snapshot
         T currentResult,
         string snapshotName,
         SnapshotNameExtension snapshotNameExtension,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
+        where T : notnull
     {
         Match((object)currentResult, snapshotName, snapshotNameExtension, matchOptions);
     }
@@ -134,7 +138,8 @@ public static class Snapshot
     public static void Match<T>(
         T currentResult,
         SnapshotFullName snapshotFullName,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
+        where T : notnull
     {
         Match((object)currentResult, snapshotFullName, matchOptions);
     }
@@ -151,7 +156,7 @@ public static class Snapshot
     /// </param>
     public static void Match(
         object currentResult,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
     {
         try
         {
@@ -185,7 +190,7 @@ public static class Snapshot
     public static void Match(
         object currentResult,
         SnapshotNameExtension snapshotNameExtension,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
     {
         Match(currentResult, FullName(snapshotNameExtension), matchOptions);
     }
@@ -207,7 +212,7 @@ public static class Snapshot
     public static void Match(
         object currentResult,
         string snapshotName,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
     {
         Match(currentResult, FullName(snapshotName), matchOptions);
     }
@@ -239,7 +244,7 @@ public static class Snapshot
         object currentResult,
         string snapshotName,
         SnapshotNameExtension snapshotNameExtension,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
     {
         Match(currentResult, FullName(snapshotName, snapshotNameExtension), matchOptions);
     }
@@ -259,7 +264,7 @@ public static class Snapshot
     public static void Match(
         object currentResult,
         SnapshotFullName snapshotFullName,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
     {
         try
         {
@@ -277,7 +282,7 @@ public static class Snapshot
     /// <returns>The full name of a snapshot.</returns>
     public static SnapshotFullName FullName()
     {
-        SnapshotFullName fullName = _snapshotName.Value;
+        SnapshotFullName? fullName = _snapshotName.Value;
 
         if (fullName is null)
         {
@@ -300,7 +305,7 @@ public static class Snapshot
     /// <returns>The full name of a snapshot.</returns>
     public static SnapshotFullName FullName(string snapshotName)
     {
-        SnapshotFullName fullName = _snapshotName.Value;
+        SnapshotFullName? fullName = _snapshotName.Value;
 
         if (fullName is null)
         {
@@ -329,7 +334,7 @@ public static class Snapshot
     public static SnapshotFullName FullName(
         SnapshotNameExtension snapshotNameExtension)
     {
-        SnapshotFullName fullName = _snapshotName.Value;
+        SnapshotFullName? fullName = _snapshotName.Value;
 
         if (fullName is null)
         {
@@ -364,7 +369,7 @@ public static class Snapshot
     public static SnapshotFullName FullName(
         string snapshotName, SnapshotNameExtension snapshotNameExtension)
     {
-        SnapshotFullName fullName = _snapshotName.Value;
+        SnapshotFullName? fullName = _snapshotName.Value;
 
         if (fullName is null)
         {

--- a/src/Snapshooter.Xunit3/SnapshotExtension.cs
+++ b/src/Snapshooter.Xunit3/SnapshotExtension.cs
@@ -16,7 +16,7 @@ public static class SnapshotExtension
     /// </param>
     public static void MatchSnapshot(
         this object currentResult,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
     {
         var cleanedObject = currentResult.RemoveUnwantedWrappers();
         Snapshot.Match(cleanedObject, matchOptions);
@@ -44,7 +44,7 @@ public static class SnapshotExtension
     public static void MatchSnapshot(
         this object currentResult,
         SnapshotNameExtension snapshotNameExtension,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
     {
         var cleanedObject = currentResult.RemoveUnwantedWrappers();
         Snapshot.Match(cleanedObject, snapshotNameExtension, matchOptions);
@@ -67,7 +67,7 @@ public static class SnapshotExtension
     public static void MatchSnapshot(
         this object currentResult,
         string snapshotName,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
     {
         var cleanedObject = currentResult.RemoveUnwantedWrappers();
         Snapshot.Match(cleanedObject, snapshotName, matchOptions);
@@ -100,7 +100,7 @@ public static class SnapshotExtension
         this object currentResult,
         string snapshotName,
         SnapshotNameExtension snapshotNameExtension,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
     {
         var cleanedObject = currentResult.RemoveUnwantedWrappers();
         Snapshot.Match(cleanedObject, snapshotName, snapshotNameExtension, matchOptions);
@@ -122,7 +122,7 @@ public static class SnapshotExtension
     public static void MatchSnapshot(
         this object currentResult,
         SnapshotFullName snapshotFullName,
-        Func<MatchOptions, MatchOptions> matchOptions = null)
+        Func<MatchOptions, MatchOptions>? matchOptions = null)
     {
         var cleanedObject = currentResult.RemoveUnwantedWrappers();
         Snapshot.Match(cleanedObject, snapshotFullName, matchOptions);

--- a/src/Snapshooter.Xunit3/Xunit3SnapshotFullNameReader.cs
+++ b/src/Snapshooter.Xunit3/Xunit3SnapshotFullNameReader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -23,12 +24,12 @@ public class Xunit3SnapshotFullNameReader : ISnapshotFullNameReader
     /// <returns>The full name of the snapshot.</returns>
     public SnapshotFullName ReadSnapshotFullName()
     {
-        SnapshotFullName snapshotFullName = null;
+        SnapshotFullName? snapshotFullName = null;
         StackFrame[] stackFrames = new StackTrace(true).GetFrames();
 
         foreach (StackFrame stackFrame in stackFrames)
         {
-            MethodBase method = stackFrame.GetMethod();
+            MethodBase? method = stackFrame.GetMethod();
             if (IsXunitTestMethod(method))
             {
                 snapshotFullName = new SnapshotFullName(
@@ -38,7 +39,7 @@ public class Xunit3SnapshotFullNameReader : ISnapshotFullNameReader
                 break;
             }
 
-            MethodBase asyncMethod = EvaluateAsynchronMethodBase(method);
+            MethodBase? asyncMethod = EvaluateAsynchronMethodBase(method);
             if (IsXunitTestMethod(asyncMethod))
             {
                 snapshotFullName = new SnapshotFullName(
@@ -66,7 +67,7 @@ public class Xunit3SnapshotFullNameReader : ISnapshotFullNameReader
         return snapshotFullName;
     }
 
-    private static bool IsXunitTestMethod(MemberInfo method)
+    private static bool IsXunitTestMethod([NotNullWhen(true)] MemberInfo? method)
     {
         bool isFactTest = IsFactTestMethod(method);
         bool isTheoryTest = IsTheoryTestMethod(method);
@@ -74,22 +75,22 @@ public class Xunit3SnapshotFullNameReader : ISnapshotFullNameReader
         return isFactTest || isTheoryTest;
     }
 
-    private static bool IsFactTestMethod(MemberInfo method)
+    private static bool IsFactTestMethod([NotNullWhen(true)] MemberInfo? method)
     {
         return method?.GetCustomAttributes(typeof(FactAttribute))?.Any() ?? false;
     }
 
-    private static bool IsTheoryTestMethod(MemberInfo method)
+    private static bool IsTheoryTestMethod([NotNullWhen(true)] MemberInfo? method)
     {
         return method?.GetCustomAttributes(typeof(TheoryAttribute))?.Any() ?? false;
     }
 
-    private static MethodBase EvaluateAsynchronMethodBase(MemberInfo method)
+    private static MethodBase? EvaluateAsynchronMethodBase(MemberInfo? method)
     {
-        Type methodDeclaringType = method?.DeclaringType;
-        Type classDeclaringType = methodDeclaringType?.DeclaringType;
+        Type? methodDeclaringType = method?.DeclaringType;
+        Type? classDeclaringType = methodDeclaringType?.DeclaringType;
 
-        MethodInfo actualMethodInfo = null;
+        MethodInfo? actualMethodInfo = null;
         if (classDeclaringType != null)
         {
             IEnumerable<MethodInfo> selectedMethodInfos =

--- a/src/Snapshooter/Core/Validators/EnvironmentValidator.cs
+++ b/src/Snapshooter/Core/Validators/EnvironmentValidator.cs
@@ -9,11 +9,11 @@ namespace Snapshooter.Core.Validators
         {
             if (!originalSnapshotExists)
             {
-                string value = Environment
+                var value = Environment
                     .GetEnvironmentVariable("SNAPSHOOTER_STRICT_MODE");
 
                 if (string.Equals(value, "on", StringComparison.Ordinal)
-                    || (bool.TryParse(value, out bool b) && b))
+                    || (bool.TryParse(value, out var b) && b))
                 {
                     throw new SnapshotNotFoundException(
                         "Strict mode is enabled and no snapshot has been found " +

--- a/src/Snapshooter/Extensions/TypeExtensions.cs
+++ b/src/Snapshooter/Extensions/TypeExtensions.cs
@@ -34,12 +34,12 @@ namespace Snapshooter.Extensions
 
         public static string GetAliasName(this Type type)
         {
-            if (_typeAlias.TryGetValue(type, out string alias))
+            if (_typeAlias.TryGetValue(type, out var alias))
             {
                 return alias;
             }
 
-            Type nullbase = Nullable.GetUnderlyingType(type);
+            Type? nullbase = Nullable.GetUnderlyingType(type);
             if (nullbase != null)
             {
                 return GetAliasName(nullbase) + "?";

--- a/src/Snapshooter/Helpers/ObjectWrapperRemover.cs
+++ b/src/Snapshooter/Helpers/ObjectWrapperRemover.cs
@@ -24,7 +24,7 @@ namespace Snapshooter
                 return objectToRemoveWrappers;
             }
 
-            PropertyInfo prop = resultType.GetProperty("Subject");
+            PropertyInfo? prop = resultType.GetProperty("Subject");
             if (prop == null)
             {
                 return objectToRemoveWrappers;

--- a/src/Snapshooter/MatchOptions.cs
+++ b/src/Snapshooter/MatchOptions.cs
@@ -484,16 +484,14 @@ namespace Snapshooter
         /// <param name="fieldPath">The json path to the field(s) to include.</param>
         public MatchOptions IncludeField(string fieldPath)
         {
-            FieldMatchOperator fieldMatchOperator =
-                _matchOperators.SingleOrDefault(op => op is IncludeMatchOperator);
+            IncludeMatchOperator? includeMatchOperator =
+                _matchOperators.OfType<IncludeMatchOperator>().SingleOrDefault();
 
-            if (fieldMatchOperator == null)
+            if (includeMatchOperator == null)
             {
-                fieldMatchOperator = new IncludeMatchOperator();
-                _matchOperators.Add(fieldMatchOperator);
+                includeMatchOperator = new IncludeMatchOperator();
+                _matchOperators.Add(includeMatchOperator);
             }
-
-            var includeMatchOperator = (IncludeMatchOperator)fieldMatchOperator;
 
             includeMatchOperator.AddFieldPath(fieldPath);
 

--- a/src/Snapshooter/SnapshotFullNameResolver.cs
+++ b/src/Snapshooter/SnapshotFullNameResolver.cs
@@ -42,7 +42,7 @@ namespace Snapshooter
         /// </param>
         /// <returns>The full name of a snapshot.</returns>
         public SnapshotFullName ResolveSnapshotFullName(
-            string snapshotName)
+            string? snapshotName)
         {
             return ResolveSnapshotFullName(snapshotName, null);
         }
@@ -64,7 +64,7 @@ namespace Snapshooter
         /// </param>
         /// <returns>The full name of a snapshot.</returns>
         public SnapshotFullName ResolveSnapshotFullName(
-            string snapshotName, string snapshotNameExtension)
+            string? snapshotName, string? snapshotNameExtension)
         {
             SnapshotFullName snapshotFullName = 
                 _snapshotFullNameReader.ReadSnapshotFullName();
@@ -105,7 +105,7 @@ namespace Snapshooter
         }
 
         private string AddSnapshotNameExtension(
-            string snapshotName, string snapshotNameExtension)
+            string snapshotName, string? snapshotNameExtension)
         {
             if (snapshotNameExtension != null)
             {

--- a/test/Snapshooter.Xunit.Tests/AcceptMatchOption/AcceptDecimal/SnapshotTests.AcceptDecimal.cs
+++ b/test/Snapshooter.Xunit.Tests/AcceptMatchOption/AcceptDecimal/SnapshotTests.AcceptDecimal.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Snapshooter.Core;
 using Snapshooter.Exceptions;
 using Snapshooter.Tests.Data;
@@ -360,6 +361,7 @@ namespace Snapshooter.Xunit.Tests.AcceptMatchOption.Decimal
             string typeName = "NotDefined")
         {
             // arrange
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
             TestPerson testPerson = TestDataBuilder
                 .TestPersonSandraSchneider()
                 .WithSize(insertNull ? null : 1.756m)
@@ -405,7 +407,8 @@ namespace Snapshooter.Xunit.Tests.AcceptMatchOption.Decimal
             Assert.Equal(
                 snapshotFileHandler.ReadSnapshot(Snapshot.FullName(
                     SnapshotNameExtension.Create("Verified"))),
-                snapshotFileHandler.ReadSnapshot(originalFullName));
+                snapshotFileHandler.ReadSnapshot(originalFullName),
+                ignoreLineEndingDifferences: true);
         }
 
         #endregion

--- a/test/Snapshooter.Xunit.Tests/AcceptMatchOption/TestHelpers/AcceptAssert.cs
+++ b/test/Snapshooter.Xunit.Tests/AcceptMatchOption/TestHelpers/AcceptAssert.cs
@@ -28,7 +28,8 @@ namespace Snapshooter.Xunit.Tests.AcceptMatchOption.TestHelpers
             Assert.Equal(
                 snapshotFileHandler.ReadSnapshot(Snapshot.FullName(
                     SnapshotNameExtension.Create("Verified"))),
-                snapshotFileHandler.ReadSnapshot(originalFullName));
+                snapshotFileHandler.ReadSnapshot(originalFullName),
+                ignoreLineEndingDifferences: true);
         }
 
         public static void AssertAcceptWrongTypeExceptionCase<TAccept, TTestee>(

--- a/test/Snapshooter.Xunit3.Tests/AcceptMatchOption/AcceptDecimal/SnapshotTests.AcceptDecimal.cs
+++ b/test/Snapshooter.Xunit3.Tests/AcceptMatchOption/AcceptDecimal/SnapshotTests.AcceptDecimal.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Snapshooter.Core;
 using Snapshooter.Exceptions;
 using Snapshooter.Tests.Data;
@@ -360,6 +361,7 @@ namespace Snapshooter.Xunit3.Tests.AcceptMatchOption.Decimal
             string typeName = "NotDefined")
         {
             // arrange
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
             TestPerson testPerson = TestDataBuilder
                 .TestPersonSandraSchneider()
                 .WithSize(insertNull ? null : 1.756m)
@@ -405,7 +407,8 @@ namespace Snapshooter.Xunit3.Tests.AcceptMatchOption.Decimal
             Assert.Equal(
                 snapshotFileHandler.ReadSnapshot(Snapshot.FullName(
                     SnapshotNameExtension.Create("Verified"))),
-                snapshotFileHandler.ReadSnapshot(originalFullName));
+                snapshotFileHandler.ReadSnapshot(originalFullName),
+                ignoreLineEndingDifferences: true);
         }
 
         #endregion

--- a/test/Snapshooter.Xunit3.Tests/AcceptMatchOption/TestHelpers/AcceptAssert.cs
+++ b/test/Snapshooter.Xunit3.Tests/AcceptMatchOption/TestHelpers/AcceptAssert.cs
@@ -28,7 +28,8 @@ namespace Snapshooter.Xunit3.Tests.AcceptMatchOption.TestHelpers
             Assert.Equal(
                 snapshotFileHandler.ReadSnapshot(Snapshot.FullName(
                     SnapshotNameExtension.Create("Verified"))),
-                snapshotFileHandler.ReadSnapshot(originalFullName));
+                snapshotFileHandler.ReadSnapshot(originalFullName),
+                ignoreLineEndingDifferences: true);
         }
 
         public static void AssertAcceptWrongTypeExceptionCase<TAccept, TTestee>(


### PR DESCRIPTION
Certain methods correctly handle `null`, but e.g. use `Func<,>` instead of `Func<,>?` as parameter type. This PR aims to improve the library with regards to nullable reference types.